### PR TITLE
mountinfo: add go.mod

### DIFF
--- a/mountinfo/go.mod
+++ b/mountinfo/go.mod
@@ -1,0 +1,3 @@
+module github.com/moby/sys/mountinfo
+
+go 1.14


### PR DESCRIPTION
This module is not dependent on any other modules, so it needs to be
added first.

Once added, we can do the same for `moby/sys/mount`