### PR TITLE
mount: add go.mod

### DIFF
--- a/mount/go.mod
+++ b/mount/go.mod
@@ -1,0 +1,8 @@
+module github.com/moby/sys/mount
+
+go 1.14
+
+require (
+	github.com/moby/sys/mountinfo v0.1.0
+	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
+)

--- a/mount/go.sum
+++ b/mount/go.sum
@@ -1,0 +1,4 @@
+github.com/moby/sys/mountinfo v0.1.0 h1:r8vMRbMAFEAfiNptYVokP+nfxPJzvRuia5e2vzXtENo=
+github.com/moby/sys/mountinfo v0.1.0/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
The version of golang.org/x/sys corresponds to the one currently used
by Moby.

Once there, it needs to be tagged, e.g.
```
git tag mount/v0.1.0
```