### PR TITLE
mount: test nitpicks

### DIFF
--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -3,6 +3,7 @@
 package mount
 
 import (
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -44,21 +45,20 @@ func TestMounted(t *testing.T) {
 		targetPath = path.Join(targetDir, "file.txt")
 	)
 
-	os.Mkdir(sourceDir, 0777)
-	os.Mkdir(targetDir, 0777)
-
-	f, err := os.Create(sourcePath)
-	if err != nil {
+	if err := os.Mkdir(sourceDir, 0777); err != nil {
 		t.Fatal(err)
 	}
-	f.WriteString("hello")
-	f.Close()
-
-	f, err = os.Create(targetPath)
-	if err != nil {
+	if err := os.Mkdir(targetDir, 0777); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+
+	if err := ioutil.WriteFile(sourcePath, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(targetPath, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := Mount(sourceDir, targetDir, "none", "bind,rw"); err != nil {
 		t.Fatal(err)
@@ -99,21 +99,20 @@ func TestMountReadonly(t *testing.T) {
 		targetPath = path.Join(targetDir, "file.txt")
 	)
 
-	os.Mkdir(sourceDir, 0777)
-	os.Mkdir(targetDir, 0777)
-
-	f, err := os.Create(sourcePath)
-	if err != nil {
+	if err := os.Mkdir(sourceDir, 0777); err != nil {
 		t.Fatal(err)
 	}
-	f.WriteString("hello")
-	f.Close()
-
-	f, err = os.Create(targetPath)
-	if err != nil {
+	if err := os.Mkdir(targetDir, 0777); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+
+	if err := ioutil.WriteFile(sourcePath, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(targetPath, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := Mount(sourceDir, targetDir, "none", "bind,ro"); err != nil {
 		t.Fatal(err)
@@ -124,8 +123,7 @@ func TestMountReadonly(t *testing.T) {
 		}
 	}()
 
-	_, err = os.OpenFile(targetPath, os.O_RDWR, 0777)
-	if err == nil {
+	if err := ioutil.WriteFile(targetPath, []byte("hello"), 0644); err == nil {
 		t.Fatal("Should not be able to open a ro file as rw")
 	}
 }

--- a/mount/mounter_linux_test.go
+++ b/mount/mounter_linux_test.go
@@ -172,7 +172,7 @@ func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 		if mi.Opts != "" {
 			for _, opt := range strings.Split(mi.Opts, ",") {
 				opt = clean(opt)
-				if !has(wantedOpts, opt) && !has(pOpts, opt) {
+				if !has(wantedOpts, opt) && !has(pOpts, opt) && opt != "relatime" {
 					t.Errorf("unexpected mount option %q, expected %q", opt, opts)
 				}
 				delete(wantedOpts, opt)

--- a/mount/sharedsubtree_linux_test.go
+++ b/mount/sharedsubtree_linux_test.go
@@ -4,6 +4,7 @@ package mount
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -340,10 +341,5 @@ func TestSubtreeUnbindable(t *testing.T) {
 }
 
 func createFile(path string) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	f.WriteString("hello world!")
-	return f.Close()
+	return ioutil.WriteFile(path, []byte("hello"), 0666)
 }


### PR DESCRIPTION
### mount: fix test for added relatime
    
The mount option `relatime` can be added by the kernel, and
this is what happens on my machine:
    
> --- FAIL: TestMount (0.00s)
>     mounter_linux_test.go:176: unexpected mount option "relatime", expected ""
> FAIL
    
Same as in commit afc7b0dd970, this option should be ignored.

##  mount: test nitpicks
    
1. Do not ignore errors from Mkdir.
2. Use ioutil.WriteFile for simplicity, to not leak fds and to not
       ignore errors from Write or Close.