### PR TITLE
mountinfo: add "empty source" test case

### DIFF
--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -616,6 +616,12 @@ func TestParseMountinfoExtraCases(t *testing.T) {
 			valid: true,
 			exp:   &Info{Mountpoint: "/mnt/point", Fstype: "aufs", Source: "none", Optional: "shared:123 extra:tag what:ever"},
 		},
+		{
+			name:  "empty source field (kernel < 5.1 bug)",
+			entry: `279 23 0:108 / /tmp/bb rw,relatime - tmpfs  rw`,
+			valid: true,
+			exp:   &Info{Mountpoint: "/tmp/bb", Fstype: "tmpfs", Source: "", VfsOpts: "rw"},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
TIL older kernels (presumably < 5.1) has a bug of not showing
the "source" field in /proc/self/mountinfo in case an empty
string was passed as the source argument to mount() syscall.

My best guess is it was fixed by the kernel commit 8f2918898eb5f
("new helpers: vfs_create_mount(), fc_mount()", Nov 4 2018) which
is `v5.1-rc1~12^2~37`, i.e. kernel 5.1 should be the one with the fix.

I was able to reproduce it on a machine with an old kernel:

```console
[kir@micros ~]$ cat a.c
 #include <sys/mount.h>
 #include <stdio.h>

int main(void) {
	int r;

	r = mount("", "/tmp/bb", "tmpfs", MS_MGC_VAL, (void*)0);
	if (r != 0) {
		perror("mount");
		return 1;
	}

	return 0;
}
[kir@micros ~]$ gcc -Wall -o a a.c
[kir@micros ~]$ mkdir /tmp/bb
[kir@micros ~]$ ./a; echo $?
mount: Operation not permitted
1
[kir@micros ~]$ sudo ./a; echo $?
0
[kir@micros ~]$ grep -F /tmp/bb /proc/self/mountinfo
279 23 0:108 / /tmp/bb rw,relatime - tmpfs  rw
[kir@micros ~]$ # notice the two spaces ^^^^^ here

[kir@micros ~]$ uname -a
Linux micros 2.6.32-042stab133.2 #1 SMP Mon Aug 27 21:07:08 MSK 2018 x86_64 x86_64 x86_64 GNU/Linux
```

The most interesting thing is this package is not affected by the bug,
working as expected, since strings.Split by a space gives an empty
element in case of two spaces.

Nevertheless, it makes sense to add a test case for it.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>