### PR TITLE
Add CI based on github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,5 @@ jobs:
       uses: actions/checkout@v2
     - name: Test
       run: make test
+    - name: Lint
+      run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.14.x]
+        platform: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,25 @@
 PACKAGES ?= mountinfo mount
+BINDIR ?= _build/bin
+
+.PHONY: all
+all: lint test
 
 .PHONY: test
 test:
 	for p in $(PACKAGES); do \
 		(cd $$p && go test -v .); \
 	done
+
+.PHONY: lint
+lint: $(BINDIR)/golangci-lint
+	$(BINDIR)/golangci-lint version
+	for p in $(PACKAGES); do \
+		(cd $$p && go mod download \
+		&& ../$(BINDIR)/golangci-lint run); \
+	done
+
+$(BINDIR)/golangci-lint: $(BINDIR)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.24.0
+
+$(BINDIR):
+	mkdir -p $(BINDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+PACKAGES ?= mountinfo mount
+
+.PHONY: test
+test:
+	for p in $(PACKAGES); do \
+		(cd $$p && go test -v .); \
+	done


### PR DESCRIPTION
Run unit tests and golangci-linter (with default config for now).

This actually uncovers a bug in mount package for windows, yay!