### PR TITLE
mount: separate mount error wrapper

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -5,51 +5,9 @@ package mount
 import (
 	"fmt"
 	"sort"
-	"strconv"
 
 	"github.com/moby/sys/mountinfo"
 )
-
-// mountError records an error from mount or unmount operation
-type mountError struct {
-	op             string
-	source, target string
-	flags          uintptr
-	data           string
-	err            error
-}
-
-func (e *mountError) Error() string {
-	out := e.op + " "
-
-	if e.source != "" {
-		out += e.source + ":" + e.target
-	} else {
-		out += e.target
-	}
-
-	if e.flags != uintptr(0) {
-		out += ", flags: 0x" + strconv.FormatUint(uint64(e.flags), 16)
-	}
-	if e.data != "" {
-		out += ", data: " + e.data
-	}
-
-	out += ": " + e.err.Error()
-	return out
-}
-
-// Cause returns the underlying cause of the error.
-// This is a convention used in github.com/pkg/errors
-func (e *mountError) Cause() error {
-	return e.err
-}
-
-// Unwrap returns the underlying error.
-// This is a convention used in golang 1.13+
-func (e *mountError) Unwrap() error {
-	return e.err
-}
 
 // Mount will mount filesystem according to the specified configuration.
 // Options must be specified like the mount or fstab unix commands:

--- a/mount/mount_errors.go
+++ b/mount/mount_errors.go
@@ -1,0 +1,46 @@
+// +build !windows
+
+package mount
+
+import "strconv"
+
+// mountError records an error from mount or unmount operation
+type mountError struct {
+	op             string
+	source, target string
+	flags          uintptr
+	data           string
+	err            error
+}
+
+func (e *mountError) Error() string {
+	out := e.op + " "
+
+	if e.source != "" {
+		out += e.source + ":" + e.target
+	} else {
+		out += e.target
+	}
+
+	if e.flags != uintptr(0) {
+		out += ", flags: 0x" + strconv.FormatUint(uint64(e.flags), 16)
+	}
+	if e.data != "" {
+		out += ", data: " + e.data
+	}
+
+	out += ": " + e.err.Error()
+	return out
+}
+
+// Cause returns the underlying cause of the error.
+// This is a convention used in github.com/pkg/errors
+func (e *mountError) Cause() error {
+	return e.err
+}
+
+// Unwrap returns the underlying error.
+// This is a convention used in golang 1.13+
+func (e *mountError) Unwrap() error {
+	return e.err
+}


### PR DESCRIPTION
This is only used for !windows, so move this to a separate
source file to avoid the following windows linter warning:

> ##[error]mount.go:14:6: type `mountError` is unused (unused)

This is just moving stuff around, no functional change