### PR TITLE
More fields for filters

### DIFF
--- a/mountinfo/mountinfo_filters.go
+++ b/mountinfo/mountinfo_filters.go
@@ -3,11 +3,12 @@ package mountinfo
 import "strings"
 
 // FilterFunc is a type defining a callback function for GetMount(),
-// used to filter out mountinfo entries we're not interested in.
+// used to filter out mountinfo entries we're not interested in,
+// and/or stop further processing if we found what we wanted.
 //
 // It takes a pointer to the Info struct (not fully populated,
-// currently only Mountpoint and Fstype are filled in),
-// and returns two booleans:
+// currently only Mountpoint, Fstype, Source, and (on Linux)
+// VfsOpts are filled in), and returns two booleans:
 //
 //  - skip: true if the entry should be skipped
 //  - stop: true if parsing should be stopped after the entry

--- a/mountinfo/mountinfo_filters.go
+++ b/mountinfo/mountinfo_filters.go
@@ -6,7 +6,8 @@ import "strings"
 // used to filter out mountinfo entries we're not interested in.
 //
 // It takes a pointer to the Info struct (not fully populated,
-// currently only Mountpoint is filled in), and returns two booleans:
+// currently only Mountpoint and Fstype are filled in),
+// and returns two booleans:
 //
 //  - skip: true if the entry should be skipped
 //  - stop: true if parsing should be stopped after the entry

--- a/mountinfo/mountinfo_freebsd.go
+++ b/mountinfo/mountinfo_freebsd.go
@@ -34,6 +34,7 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 		var skip, stop bool
 		mountinfo.Mountpoint = C.GoString(&entry.f_mntonname[0])
 		mountinfo.Fstype = C.GoString(&entry.f_fstypename[0])
+		mountinfo.Source = C.GoString(&entry.f_mntfromname[0])
 
 		if filter != nil {
 			// filter out entries we're not interested in
@@ -42,8 +43,6 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 				continue
 			}
 		}
-
-		mountinfo.Source = C.GoString(&entry.f_mntfromname[0])
 
 		out = append(out, &mountinfo)
 		if stop {

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -71,12 +71,13 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		p := &Info{}
 
 		// Fill in the fields that a filter might check
-		// (currently only Mountpoint and Fstype)
 		p.Mountpoint, err = strconv.Unquote(`"` + fields[4] + `"`)
 		if err != nil {
 			return nil, fmt.Errorf("Parsing '%s' failed: unable to unquote mount point field: %w", fields[4], err)
 		}
 		p.Fstype = fields[sepIdx+1]
+		p.Source = fields[sepIdx+2]
+		p.VfsOpts = fields[sepIdx+3]
 
 		// Run a filter soon so we can skip parsing/adding entries
 		// the caller is not interested in
@@ -116,9 +117,6 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		default:
 			p.Optional = strings.Join(fields[6:sepIdx-1], " ")
 		}
-
-		p.Source = fields[sepIdx+2]
-		p.VfsOpts = fields[sepIdx+3]
 
 		out = append(out, p)
 		if stop {


### PR DESCRIPTION
Make `Source` and `VfsOpts` available to filters.

Cgroup parsing code in opencontainers/runc may benefit.

Update the docs accordingly.