### PR TITLE
mountinfo: fix windows build

### DIFF
--- a/mountinfo/mountinfo_unsupported.go
+++ b/mountinfo/mountinfo_unsupported.go
@@ -4,9 +4,14 @@ package mountinfo
 
 import (
 	"fmt"
+	"io"
 	"runtime"
 )
 
-func parseMountTable(f FilterFunc) ([]*Info, error) {
+func parseMountTable(_ FilterFunc) ([]*Info, error) {
 	return nil, fmt.Errorf("mount.parseMountTable is not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+func parseInfoFile(_ io.Reader, f FilterFunc) ([]*Info, error) {
+	return parseMountTable(f)
 }

--- a/mountinfo/mountinfo_windows.go
+++ b/mountinfo/mountinfo_windows.go
@@ -1,6 +1,12 @@
 package mountinfo
 
-func parseMountTable(f FilterFunc) ([]*Info, error) {
+import "io"
+
+func parseMountTable(_ FilterFunc) ([]*Info, error) {
 	// Do NOT return an error!
 	return nil, nil
+}
+
+func parseInfoFile(_ io.Reader, f FilterFunc) ([]*Info, error) {
+	return parseMountTable(f)
 }


### PR DESCRIPTION
When compiling for windows, we get this error:

> GOOS="windows" GOARCH="amd64" GOARM=""
> vendor/github.com/moby/sys/mountinfo/mountinfo.go:16:9: undefined: parseInfoFile

The problem is newly added GetMountsFromReader() (see https://github.com/moby/sys/pull/6)

Amend the `_windows.go` and `_unsupported.go` to fix.

NOTE that eventually we need to deprecate windows support for this
library, since it's not really doing anything.