### PR TITLE
Makefile: simplify test, and exclude macOS (darwin)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,12 @@ all: lint test
 
 .PHONY: test
 test:
-	for p in $(PACKAGES); do \
-		(cd $$p && go test -v .); \
-	done
+	go test -v ./...
 
 .PHONY: lint
 lint: $(BINDIR)/golangci-lint
 	$(BINDIR)/golangci-lint version
+	go mod download ./...
 	for p in $(PACKAGES); do \
 		(cd $$p && go mod download \
 		&& ../$(BINDIR)/golangci-lint run); \

--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!darwin
 
 package mount
 

--- a/mountinfo/mountinfo_test.go
+++ b/mountinfo/mountinfo_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!darwin
 
 package mountinfo
 


### PR DESCRIPTION
Excluding darwin, as this package doesn't support it, but a developer may try running the tests on a Mac.
