### PR TITLE
Exclude macOS (darwin)

### DIFF
--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!darwin
 
 package mount
 

--- a/mountinfo/mountinfo_test.go
+++ b/mountinfo/mountinfo_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!darwin
 
 package mountinfo
 


### PR DESCRIPTION
Excluding darwin, as these packages don't support it, but a developer may try running the tests on a Mac.
