### PR TITLE
mountinfo: SingleEntryFilter support symlink

### DIFF
--- a/mountinfo/mountinfo_filters.go
+++ b/mountinfo/mountinfo_filters.go
@@ -1,6 +1,9 @@
 package mountinfo
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // FilterFunc is a type defining a callback function for GetMount(),
 // used to filter out mountinfo entries we're not interested in,
@@ -26,6 +29,11 @@ func PrefixFilter(prefix string) FilterFunc {
 // SingleEntryFilter looks for a specific entry
 func SingleEntryFilter(mp string) FilterFunc {
 	return func(m *Info) (bool, bool) {
+		// Resolve any symlinks in mountpoint, kernel would do the same and use the resolved path in /proc/<pid>/mountinfo.
+		if resolved, err := filepath.EvalSymlinks(mp); err == nil {
+			mp = resolved
+		}
+
 		if m.Mountpoint == mp {
 			return false, true // don't skip, stop now
 		}


### PR DESCRIPTION
SingleEntryFilter supports matching cases with symlink in mountpoint.

In Linux, if there is a symlink in the mountpoint, the symlink will be resolved in the mountinfo file. mountpoint matching will fail.

For example:
```console
ln -s /mnt/ /tmp/mnt_symlink
mount -t ext4 /dev/vdb1 /tmp/mnt_symlink/disk1
```
What you see in mountinfo is `/mnt/disk1`, not `/tmp/mnt_symlink/disk1`.   
mountinfo.Mounted("/tmp/mnt_symlink/disk1") will return `false`, not `true` 

