### PR TITLE
mountinfo: fix path unescaping

### DIFF
--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -75,8 +75,14 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Parsing '%s' failed: mount point: %w", fields[4], err)
 		}
-		p.Fstype = fields[sepIdx+1]
-		p.Source = fields[sepIdx+2]
+		p.Fstype, err = unescape(fields[sepIdx+1])
+		if err != nil {
+			return nil, fmt.Errorf("Parsing '%s' failed: fstype: %w", fields[sepIdx+1], err)
+		}
+		p.Source, err = unescape(fields[sepIdx+2])
+		if err != nil {
+			return nil, fmt.Errorf("Parsing '%s' failed: source: %w", fields[sepIdx+2], err)
+		}
 		p.VfsOpts = fields[sepIdx+3]
 
 		// Run a filter soon so we can skip parsing/adding entries

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -71,9 +71,9 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		p := &Info{}
 
 		// Fill in the fields that a filter might check
-		p.Mountpoint, err = strconv.Unquote(`"` + fields[4] + `"`)
+		p.Mountpoint, err = unescape(fields[4])
 		if err != nil {
-			return nil, fmt.Errorf("Parsing '%s' failed: unable to unquote mount point field: %w", fields[4], err)
+			return nil, fmt.Errorf("Parsing '%s' failed: mount point: %w", fields[4], err)
 		}
 		p.Fstype = fields[sepIdx+1]
 		p.Source = fields[sepIdx+2]
@@ -101,9 +101,9 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		p.Major, _ = strconv.Atoi(mm[0])
 		p.Minor, _ = strconv.Atoi(mm[1])
 
-		p.Root, err = strconv.Unquote(`"` + fields[3] + `"`)
+		p.Root, err = unescape(fields[3])
 		if err != nil {
-			return nil, fmt.Errorf("Parsing '%s' failed: unable to unquote root field: %w", fields[3], err)
+			return nil, fmt.Errorf("Parsing '%s' failed: root: %w", fields[3], err)
 		}
 
 		p.Opts = fields[5]
@@ -149,4 +149,62 @@ func PidMountInfo(pid int) ([]*Info, error) {
 	defer f.Close()
 
 	return parseInfoFile(f, nil)
+}
+
+// A few specific characters in mountinfo path entries (root and mountpoint)
+// are escaped using a backslash followed by a character's ascii code in octal.
+//
+//   space              -- as \040
+//   tab (aka \t)       -- as \011
+//   newline (aka \n)   -- as \012
+//   backslash (aka \\) -- as \134
+//
+// This function converts path from mountinfo back, i.e. it unescapes the above sequences.
+func unescape(path string) (string, error) {
+	// try to avoid copying
+	if strings.IndexByte(path, '\\') == -1 {
+		return path, nil
+	}
+
+	// The following code is UTF-8 transparent as it only looks for some
+	// specific characters (backslach and 0..7) with values < utf8.RuneSelf,
+	// and everything else is passed through as is.
+	buf := make([]byte, len(path))
+	bufLen := 0
+	for i := 0; i < len(path); i++ {
+		if path[i] != '\\' {
+			buf[bufLen] = path[i]
+			bufLen++
+			continue
+		}
+		s := path[i:]
+		if len(s) < 4 {
+			// too short
+			return "", fmt.Errorf("bad escape sequence %q: too short", s)
+		}
+		c := s[1]
+		switch c {
+		case '0', '1', '2', '3', '4', '5', '6', '7':
+			v := c - '0'
+			for j := 2; j < 4; j++ { // one digit already; two more
+				x := s[j] - '0'
+				if x < 0 || x > 7 {
+					return "", fmt.Errorf("bad escape sequence %q: not a digit", s[:3])
+				}
+				v = (v << 3) | x
+			}
+			if v > 255 {
+				return "", fmt.Errorf("bad escape sequence %q: out of range" + s[:3])
+			}
+			buf[bufLen] = v
+			bufLen++
+			i += 3
+			continue
+		default:
+			return "", fmt.Errorf("bad escape sequence %q: not a digit" + s[:3])
+
+		}
+	}
+
+	return string(buf[:bufLen]), nil
 }


### PR DESCRIPTION
Moby PR https://github.com/moby/moby/pull/38977 and containerd PR https://github.com/containerd/containerd/pull/3159
added the handing of escape sequences in mountinfo paths (root and mountpoint fields).

Unfortunately, it also broke the handling of paths containing double
quotes, as it was pointed out in https://github.com/containerd/containerd/issues/4257

The solution is to stop using strconv.Unquote and write our own
specialized function to deal with escape sequences.

Unit tests added.

In addition, unescape the fstype and source fields (the first two after the `-` separator, since kernel escapes those as well.