### PR TITLE
mountinfo/TestGetMounts: fix for Ubuntu build system

### DIFF
--- a/mountinfo/mountinfo_test.go
+++ b/mountinfo/mountinfo_test.go
@@ -10,14 +10,7 @@ func TestGetMounts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root := false
-	for _, entry := range mounts {
-		if entry.Mountpoint == "/" {
-			root = true
-		}
-	}
-
-	if !root {
-		t.Fatal("/ should be mounted at least")
+	if len(mounts) < 2 {
+		t.Fatalf("should have at least two mounts, got %d: %+v", len(mounts), mounts)
 	}
 }


### PR DESCRIPTION
Apparently, Ubuntu build system is some sort of a chroot which does not
have `/` mount in its /proc/self/mountinfo. This leads to test failure
described in https://github.com/moby/sys/issues/17.

The fix is not to require a specific mount (even `/` that must exist but
apparently does not in some setups). Instead, let's require at least 2
mounts, doesn't matter which ones.

For reference, his test case was added by
https://github.com/moby/moby/pull/4812

Fixes:  https://github.com/moby/sys/issues/17