### PR TITLE
ci: update golangci-lint to 1.26.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint: $(BINDIR)/golangci-lint
 	done
 
 $(BINDIR)/golangci-lint: $(BINDIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.24.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.26.0
 
 $(BINDIR):
 	mkdir -p $(BINDIR)


### PR DESCRIPTION
Changes: https://github.com/golangci/golangci-lint/releases

(I am not using 1.27.0 as it has a windows installation bug: golangci/golangci-lint#1202)