### PR TITLE
mount.RecursiveUnmount: add a fast path

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -17,8 +17,8 @@ func Mount(device, target, mType, options string) error {
 	return mount(device, target, mType, uintptr(flag), data)
 }
 
-// Unmount lazily unmounts a filesystem on supported platforms, otherwise
-// does a normal unmount.
+// Unmount lazily unmounts a filesystem on supported platforms, otherwise does
+// a normal unmount.  If target is not a mount point, no error is returned.
 func Unmount(target string) error {
 	return unmount(target, mntDetach)
 }

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -23,9 +23,20 @@ func Unmount(target string) error {
 	return unmount(target, mntDetach)
 }
 
-// RecursiveUnmount unmounts the target and all mounts underneath, starting with
-// the deepsest mount first.
+// RecursiveUnmount unmounts the target and all mounts underneath, starting
+// with the deepest mount first. The argument does not have to be a mount
+// point itself.
 func RecursiveUnmount(target string) error {
+	// Fast path, works if target is a mount point that can be unmounted.
+	// On Linux, mntDetach flag ensures a recursive unmount.  For other
+	// platforms, if there are submounts, we'll get EBUSY (and fall back
+	// to the slow path). NOTE we do not ignore EINVAL here as target might
+	// not be a mount point itself (but there can be mounts underneath).
+	if err := unmountBare(target, mntDetach); err == nil {
+		return nil
+	}
+
+	// Slow path: get all submounts, sort, unmount one by one.
 	mounts, err := mountinfo.GetMounts(mountinfo.PrefixFilter(target))
 	if err != nil {
 		return err

--- a/mount/unmount_unix.go
+++ b/mount/unmount_unix.go
@@ -4,8 +4,12 @@ package mount
 
 import "golang.org/x/sys/unix"
 
+func unmountBare(target string, flags int) error {
+	return unix.Unmount(target, flags)
+}
+
 func unmount(target string, flags int) error {
-	err := unix.Unmount(target, flags)
+	err := unmountBare(target, flags)
 	if err == nil || err == unix.EINVAL {
 		// Ignore "not mounted" error here. Note the same error
 		// can be returned if flags are invalid, so this code

--- a/mount/unmount_unsupported.go
+++ b/mount/unmount_unsupported.go
@@ -2,6 +2,10 @@
 
 package mount
 
-func unmount(target string, flag int) error {
+func unmountBare(_ string, _ int) error {
+	panic("Not implemented")
+}
+
+func unmount(_ string, _ int) error {
 	panic("Not implemented")
 }


### PR DESCRIPTION
In many cases, this is called with an argument that is a mount point
itself. In such case, if we're on Linux, MNT_DETACH ensures that the
umount is recursive (which is its nice, but a little known feature).
For other platforms, if the mount does not have any submounts
underneath and is not busy, it will be unmounted.
    
In the above case, we no longer have to parse mountinfo and perform
the unmounts one-by-one.
    
IOW this should speed up RecursiveUnmount() for some cases, without
breaking the compatibility.
    
While at it
 - fix a typo in doc;
 - add that the argument does not have to be a mount point;
 - improve mount.Unmount doc.

Fixes: https://github.com/moby/sys/issues/21
