### PR TITLE
mount.Mounted: normalize the path argument

### DIFF
--- a/mountinfo/doc.go
+++ b/mountinfo/doc.go
@@ -14,8 +14,7 @@
 // parse filters while reading mountinfo. A filter can skip some entries, or stop
 // processing the rest of the file once the needed information is found.
 //
-// For functions that have path as an argument (such as Mounted or various filters),
-// the argument must be
+// For mountinfo filters that accept path as an argument, it must be:
 //  - an absolute path;
 //  - having all symlinks resolved;
 //  - being cleaned.

--- a/mountinfo/mountinfo_unix.go
+++ b/mountinfo/mountinfo_unix.go
@@ -3,10 +3,25 @@
 package mountinfo
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
+
+func normalizePath(path string) (realPath string, err error) {
+	if realPath, err = filepath.Abs(path); err != nil {
+		return "", fmt.Errorf("unable to get absolute path for %q: %w", path, err)
+	}
+	if realPath, err = filepath.EvalSymlinks(realPath); err != nil {
+		return "", fmt.Errorf("failed to canonicalise path for %q: %w", path, err)
+	}
+	if _, err := os.Stat(realPath); err != nil {
+		return "", fmt.Errorf("failed to stat target %q of %q: %w", realPath, path, err)
+	}
+	return realPath, nil
+}
 
 func mounted(path string) (bool, error) {
 	var st unix.Stat_t
@@ -24,6 +39,11 @@ func mounted(path string) (bool, error) {
 			// so definitely a mount point.
 			return true, nil
 		}
+	}
+
+	path, err = normalizePath(path)
+	if err != nil {
+		return false, err
 	}
 
 	entries, err := GetMounts(SingleEntryFilter(path))


### PR DESCRIPTION
Currently, the path provided to mount.Mounted() must be
 - an absolute path;
 - with all symlinks resolved;
 - cleaned.

Otherwise, the function will most probably return a false negative in
case of a bind mount (i.e. "not mounted" while the path is in fact
mounted).

This commit removes the above limitation by doing a path normalization.
This should slow things down but it's not affecting the fast path, so
the slowdown will only be seen in the bind mount case.

Fixes: https://github.com/moby/sys/issues/27