### PR TITLE
ci: update golangci-lint to 1.31.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint: $(BINDIR)/golangci-lint
 	done
 
 $(BINDIR)/golangci-lint: $(BINDIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.26.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.31.0
 
 $(BINDIR):
 	mkdir -p $(BINDIR)


### PR DESCRIPTION
Changes: https://github.com/golangci/golangci-lint/releases