### PR TITLE
Add support for OpenBSD in addition to FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 PACKAGES ?= mountinfo mount
 BINDIR ?= _build/bin
 CROSS ?= linux/arm linux/arm64 linux/ppc64le linux/s390x \
-	freebsd/amd64 darwin/amd64 darwin/arm64 windows/amd64
+	freebsd/amd64 openbsd/amd64 darwin/amd64 darwin/arm64 windows/amd64
 
 .PHONY: all
 all: lint test cross

--- a/mount/flags_bsd.go
+++ b/mount/flags_bsd.go
@@ -1,4 +1,4 @@
-// +build freebsd
+// +build freebsd openbsd
 
 package mount
 

--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin
+// +build !darwin,!windows
 
 package mount
 

--- a/mount/mounter_bsd.go
+++ b/mount/mounter_bsd.go
@@ -1,4 +1,4 @@
-// +build freebsd cgo
+// +build freebsd,cgo openbsd,cgo
 
 package mount
 

--- a/mount/mounter_linux_test.go
+++ b/mount/mounter_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package mount
 
 import (

--- a/mount/mounter_unsupported.go
+++ b/mount/mounter_unsupported.go
@@ -1,7 +1,7 @@
-// +build freebsd,!cgo
+// +build !linux,!freebsd,!openbsd,!windows freebsd,!cgo openbsd,!cgo
 
 package mount
 
 func mount(device, target, mType string, flag uintptr, data string) error {
-	panic("cgo required on freebsd")
+	panic("cgo required on freebsd and openbsd")
 }

--- a/mount/sharedsubtree_linux_test.go
+++ b/mount/sharedsubtree_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package mount
 
 import (

--- a/mountinfo/doc.go
+++ b/mountinfo/doc.go
@@ -1,6 +1,6 @@
 // Package mountinfo provides a set of functions to retrieve information about OS mounts.
 //
-// Currently it supports Linux. For historical reasons, there is also some support for FreeBSD,
+// Currently it supports Linux. For historical reasons, there is also some support for FreeBSD and OpenBSD,
 // and a shallow implementation for Windows, but in general this is Linux-only package, so
 // the rest of the document only applies to Linux, unless explicitly specified otherwise.
 //

--- a/mountinfo/mounted_unix.go
+++ b/mountinfo/mounted_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd,cgo
+// +build linux freebsd,cgo openbsd,cgo
 
 package mountinfo
 

--- a/mountinfo/mountinfo_bsd.go
+++ b/mountinfo/mountinfo_bsd.go
@@ -1,3 +1,5 @@
+// +build freebsd,cgo openbsd,cgo
+
 package mountinfo
 
 /*
@@ -54,7 +56,7 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 
 func mounted(path string) (bool, error) {
 	// Fast path: compare st.st_dev fields.
-	// This should always work for FreeBSD.
+	// This should always work for FreeBSD and OpenBSD.
 	mounted, err := mountedByStat(path)
 	if err == nil {
 		return mounted, nil

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -1,5 +1,3 @@
-// +build go1.13
-
 package mountinfo
 
 import (

--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package mountinfo
 
 import (

--- a/mountinfo/mountinfo_unsupported.go
+++ b/mountinfo/mountinfo_unsupported.go
@@ -1,4 +1,4 @@
-// +build !windows,!linux,!freebsd freebsd,!cgo
+// +build !windows,!linux,!freebsd,!openbsd freebsd,!cgo openbsd,!cgo
 
 package mountinfo
 


### PR DESCRIPTION
I am looking at using these modules in containerd, so that we can
reduce the effort of maintaining "mountinfo" implementations.

The containerd variant of this module currently supports OpenBSD in
addition to FreeBSD.

This patch bring in changes similar to the ones made in containerd in:

https://github.com/containerd/containerd/commit/0828b7aa96b55e36a9594e3b98a3f6800bc0734a
