### PR TITLE
mountinfo: add test-cases for double quotes in Linux Mountinfo

### DIFF
--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -424,6 +424,14 @@ const (
 	mountInfoWithSpaces = `486 28 252:1 / /mnt/foo\040bar rw,relatime shared:243 - ext4 /dev/vda1 rw,data=ordered
 31 21 0:23 / /DATA/foo_bla_bla rw,relatime - cifs //foo/BLA\040BLA\040BLA/ rw,sec=ntlm,cache=loose,unc=\\foo\BLA BLA BLA,username=my_login,domain=mydomain.com,uid=12345678,forceuid,gid=12345678,forcegid,addr=10.1.30.10,file_mode=0755,dir_mode=0755,nounix,rsize=61440,wsize=65536,actimeo=1
 649 94 259:5 /tmp/newline\012tab\011space\040backslash\134quote1'quote2" /tmp/newline\012tab\011space\040backslash\134quote1'quote2" rw,relatime shared:47 - ext4 /dev/nvme0n1p5 rw,seclabel`
+
+	mountInfoWithQuotes = `1046 30 253:1 /tmp/bar /var/lib/kubelet/pods/98d150a4-d814-4d52-9068-b10f62d7a895/volumes/kubernetes.io~empty-dir/tmp-dir/"var rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro
+1046 30 253:1 /tmp/bar /tmp/"foo" rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro
+1060 30 253:1 /tmp/bar /tmp/\134"foo\134" rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro
+1060 30 253:1 /tmp/"what's\040up?" /tmp/foo rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro
+1100 1060 253:1 /tmp/'what's\040up?' /tmp/foo rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro` +
+		// Last must be appended because literal backticks are also valid.
+		"\n1047 30 253:1 /tmp/`foo` /tmp/bar rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro"
 )
 
 func TestParseFedoraMountinfo(t *testing.T) {
@@ -526,6 +534,103 @@ tab	space backslash\quote1'quote2"`,
 			Fstype:   "ext4",
 			Source:   `/dev/nvme0n1p5`,
 			VfsOpts:  `rw,seclabel`,
+		},
+	}
+
+	if len(infos) != len(expected) {
+		t.Fatalf("expected %d entries, got %d", len(expected), len(infos))
+	}
+	for i, mi := range expected {
+		if *infos[i] != mi {
+			t.Fatalf("expected %#v, got %#v", mi, infos[i])
+		}
+	}
+}
+
+func TestParseMountinfoWithQuotes(t *testing.T) {
+	r := bytes.NewBuffer([]byte(mountInfoWithQuotes))
+	infos, err := parseInfoFile(r, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []Info{
+		{
+			ID:         1046,
+			Parent:     30,
+			Major:      253,
+			Minor:      1,
+			Root:       "/tmp/bar",
+			Mountpoint: `/var/lib/kubelet/pods/98d150a4-d814-4d52-9068-b10f62d7a895/volumes/kubernetes.io~empty-dir/tmp-dir/"var`,
+			Opts:       "rw,relatime",
+			Optional:   "shared:1",
+			Fstype:     "ext4",
+			Source:     "/dev/mapper/ubuntu--vg-root",
+			VfsOpts:    "rw,errors=remount-ro",
+		},
+		{
+			ID:         1046,
+			Parent:     30,
+			Major:      253,
+			Minor:      1,
+			Root:       "/tmp/bar",
+			Mountpoint: `/tmp/"foo"`,
+			Opts:       "rw,relatime",
+			Optional:   "shared:1",
+			Fstype:     "ext4",
+			Source:     "/dev/mapper/ubuntu--vg-root",
+			VfsOpts:    "rw,errors=remount-ro",
+		},
+		{
+			ID:         1060,
+			Parent:     30,
+			Major:      253,
+			Minor:      1,
+			Root:       "/tmp/bar",
+			Mountpoint: `/tmp/\"foo\"`,
+			Opts:       "rw,relatime",
+			Optional:   "shared:1",
+			Fstype:     "ext4",
+			Source:     "/dev/mapper/ubuntu--vg-root",
+			VfsOpts:    "rw,errors=remount-ro",
+		},
+		{
+			ID:         1060,
+			Parent:     30,
+			Major:      253,
+			Minor:      1,
+			Root:       `/tmp/"what's up?"`,
+			Mountpoint: "/tmp/foo",
+			Opts:       "rw,relatime",
+			Optional:   "shared:1",
+			Fstype:     "ext4",
+			Source:     "/dev/mapper/ubuntu--vg-root",
+			VfsOpts:    "rw,errors=remount-ro",
+		},
+		{
+			ID:         1100,
+			Parent:     1060,
+			Major:      253,
+			Minor:      1,
+			Root:       `/tmp/'what's up?'`,
+			Mountpoint: "/tmp/foo",
+			Opts:       "rw,relatime",
+			Optional:   "shared:1",
+			Fstype:     "ext4",
+			Source:     "/dev/mapper/ubuntu--vg-root",
+			VfsOpts:    "rw,errors=remount-ro",
+		},
+		{
+			ID:         1047,
+			Parent:     30,
+			Major:      253,
+			Minor:      1,
+			Root:       "/tmp/`foo`",
+			Mountpoint: "/tmp/bar",
+			Opts:       "rw,relatime",
+			Optional:   "shared:1",
+			Fstype:     "ext4",
+			Source:     "/dev/mapper/ubuntu--vg-root",
+			VfsOpts:    "rw,errors=remount-ro",
 		},
 	}
 


### PR DESCRIPTION
This adds tests for handling paths containing double quotes, and is the equivalent of the tests added in containerd/containerd#4325
