### PR TITLE
mountinfo: use idiomatic naming for fields

### DIFF
--- a/mountinfo/mountinfo.go
+++ b/mountinfo/mountinfo.go
@@ -46,18 +46,18 @@ type Info struct {
 	// Mountpoint indicates the mount point relative to the process's root.
 	Mountpoint string
 
-	// Opts represents mount-specific options.
-	Opts string
+	// Options represents mount-specific options.
+	Options string
 
 	// Optional represents optional fields.
 	Optional string
 
-	// Fstype indicates the type of filesystem, such as EXT3.
-	Fstype string
+	// FSType indicates the type of filesystem, such as EXT3.
+	FSType string
 
 	// Source indicates filesystem specific information or "none".
 	Source string
 
-	// VfsOpts represents per super block options.
-	VfsOpts string
+	// VFSOptions represents per super block options.
+	VFSOptions string
 }

--- a/mountinfo/mountinfo_bsd.go
+++ b/mountinfo/mountinfo_bsd.go
@@ -35,7 +35,7 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 		var mountinfo Info
 		var skip, stop bool
 		mountinfo.Mountpoint = C.GoString(&entry.f_mntonname[0])
-		mountinfo.Fstype = C.GoString(&entry.f_fstypename[0])
+		mountinfo.FSType = C.GoString(&entry.f_fstypename[0])
 		mountinfo.Source = C.GoString(&entry.f_mntfromname[0])
 
 		if filter != nil {

--- a/mountinfo/mountinfo_filters.go
+++ b/mountinfo/mountinfo_filters.go
@@ -49,7 +49,7 @@ func ParentsFilter(path string) FilterFunc {
 func FstypeFilter(fstype ...string) FilterFunc {
 	return func(m *Info) (bool, bool) {
 		for _, t := range fstype {
-			if m.Fstype == t {
+			if m.FSType == t {
 				return false, false // don't skip, keep going
 			}
 		}

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -79,7 +79,7 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Parsing '%s' failed: mount point: %w", fields[4], err)
 		}
-		p.Fstype, err = unescape(fields[sepIdx+1])
+		p.FSType, err = unescape(fields[sepIdx+1])
 		if err != nil {
 			return nil, fmt.Errorf("Parsing '%s' failed: fstype: %w", fields[sepIdx+1], err)
 		}
@@ -87,7 +87,7 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Parsing '%s' failed: source: %w", fields[sepIdx+2], err)
 		}
-		p.VfsOpts = fields[sepIdx+3]
+		p.VFSOptions = fields[sepIdx+3]
 
 		// Run a filter early so we can skip parsing/adding entries
 		// the caller is not interested in
@@ -116,7 +116,7 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 			return nil, fmt.Errorf("Parsing '%s' failed: root: %w", fields[3], err)
 		}
 
-		p.Opts = fields[5]
+		p.Options = fields[5]
 
 		// zero or more optional fields
 		switch {

--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -465,11 +465,11 @@ func TestParseFedoraMountinfoFields(t *testing.T) {
 		Minor:      3,
 		Root:       "/",
 		Mountpoint: "/proc",
-		Opts:       "rw,nosuid,nodev,noexec,relatime",
+		Options:    "rw,nosuid,nodev,noexec,relatime",
 		Optional:   "shared:5",
-		Fstype:     "proc",
+		FSType:     "proc",
 		Source:     "proc",
-		VfsOpts:    "rw",
+		VFSOptions: "rw",
 	}
 
 	if *infos[0] != mi {
@@ -491,11 +491,11 @@ func TestParseMountinfoWithSpaces(t *testing.T) {
 			Minor:      1,
 			Root:       "/",
 			Mountpoint: "/mnt/foo bar",
-			Opts:       "rw,relatime",
+			Options:    "rw,relatime",
 			Optional:   "shared:243",
-			Fstype:     "ext4",
+			FSType:     "ext4",
 			Source:     "/dev/vda1",
-			VfsOpts:    "rw,data=ordered",
+			VFSOptions: "rw,data=ordered",
 		},
 		{
 			ID:         31,
@@ -504,11 +504,11 @@ func TestParseMountinfoWithSpaces(t *testing.T) {
 			Minor:      23,
 			Root:       "/",
 			Mountpoint: "/DATA/foo_bla_bla",
-			Opts:       "rw,relatime",
+			Options:    "rw,relatime",
 			Optional:   "",
-			Fstype:     "cifs",
+			FSType:     "cifs",
 			Source:     `//foo/BLA BLA BLA/`,
-			VfsOpts:    `rw,sec=ntlm,cache=loose,unc=\\foo\BLA`,
+			VFSOptions: `rw,sec=ntlm,cache=loose,unc=\\foo\BLA`,
 		},
 		{
 			ID:     649,
@@ -519,11 +519,11 @@ func TestParseMountinfoWithSpaces(t *testing.T) {
 tab	space backslash\quote1'quote2"`,
 			Mountpoint: `/tmp/newline
 tab	space backslash\quote1'quote2"`,
-			Opts:     "rw,relatime",
-			Optional: "shared:47",
-			Fstype:   "ext4",
-			Source:   `/dev/nvme0n1p5`,
-			VfsOpts:  `rw,seclabel`,
+			Options:    "rw,relatime",
+			Optional:   "shared:47",
+			FSType:     "ext4",
+			Source:     `/dev/nvme0n1p5`,
+			VFSOptions: `rw,seclabel`,
 		},
 	}
 
@@ -616,25 +616,25 @@ func TestParseMountinfoExtraCases(t *testing.T) {
 			name:  "extra fields at the end", // which we currently discard
 			entry: `251 15 0:3573 / /mnt/point rw,relatime - aufs none rw,unc=buggy but we cope`,
 			valid: true,
-			exp:   &Info{Mountpoint: "/mnt/point", Fstype: "aufs", Source: "none"},
+			exp:   &Info{Mountpoint: "/mnt/point", FSType: "aufs", Source: "none"},
 		},
 		{
 			name:  "one optional field",
 			entry: `251 15 0:3573 / /mnt/point rw,relatime shared:123 - aufs none rw`,
 			valid: true,
-			exp:   &Info{Mountpoint: "/mnt/point", Fstype: "aufs", Source: "none", Optional: "shared:123 extra:tag what:ever"},
+			exp:   &Info{Mountpoint: "/mnt/point", FSType: "aufs", Source: "none", Optional: "shared:123 extra:tag what:ever"},
 		},
 		{
 			name:  "extra optional fields", // which we carefully gather
 			entry: `251 15 0:3573 / /mnt/point rw,relatime shared:123 extra:tag what:ever key:value - aufs none rw`,
 			valid: true,
-			exp:   &Info{Mountpoint: "/mnt/point", Fstype: "aufs", Source: "none", Optional: "shared:123 extra:tag what:ever"},
+			exp:   &Info{Mountpoint: "/mnt/point", FSType: "aufs", Source: "none", Optional: "shared:123 extra:tag what:ever"},
 		},
 		{
 			name:  "empty source field (kernel < 5.1 bug)",
 			entry: `279 23 0:108 / /tmp/bb rw,relatime - tmpfs  rw`,
 			valid: true,
-			exp:   &Info{Mountpoint: "/tmp/bb", Fstype: "tmpfs", Source: "", VfsOpts: "rw"},
+			exp:   &Info{Mountpoint: "/tmp/bb", FSType: "tmpfs", Source: "", VFSOptions: "rw"},
 		},
 	}
 
@@ -661,8 +661,8 @@ func TestParseMountinfoExtraCases(t *testing.T) {
 		if tc.exp.Mountpoint != "" && tc.exp.Mountpoint != i.Mountpoint {
 			t.Errorf("case %q: expected mp %s, got %s", tc.name, tc.exp.Mountpoint, i.Mountpoint)
 		}
-		if tc.exp.Fstype != "" && tc.exp.Fstype != i.Fstype {
-			t.Errorf("case %q: expected fs %s, got %s", tc.name, tc.exp.Fstype, i.Fstype)
+		if tc.exp.FSType != "" && tc.exp.FSType != i.FSType {
+			t.Errorf("case %q: expected fs %s, got %s", tc.name, tc.exp.FSType, i.FSType)
 		}
 		if tc.exp.Source != "" && tc.exp.Source != i.Source {
 			t.Errorf("case %q: expected src %s, got %s", tc.name, tc.exp.Source, i.Source)


### PR DESCRIPTION
follow-up to https://github.com/moby/sys/pull/32

I am looking at using these modules in containerd, so that we can reduce the effort of maintaining "mountinfo" implementations.

This change renames the info fields to match the ones used in containerd, which are more "correct" from a Go naming perspective: https://github.com/containerd/containerd/commit/8cd218237b49b41bffa0035393143571ec01b157

This will be a breaking changes for consumers of this package, but we're still pre-v1.0.0, so if we want to make these changes, this is still possible now.