### PR TITLE
mount: use MNT_* flags from golang.org/x/sys/unix on freebsd

### DIFF
--- a/mount/flags_freebsd.go
+++ b/mount/flags_freebsd.go
@@ -1,28 +1,25 @@
-// +build freebsd,cgo
+// +build freebsd
 
 package mount
 
-/*
-#include <sys/mount.h>
-*/
-import "C"
+import "golang.org/x/sys/unix"
 
 const (
 	// RDONLY will mount the filesystem as read-only.
-	RDONLY = C.MNT_RDONLY
+	RDONLY = unix.MNT_RDONLY
 
 	// NOSUID will not allow set-user-identifier or set-group-identifier bits to
 	// take effect.
-	NOSUID = C.MNT_NOSUID
+	NOSUID = unix.MNT_NOSUID
 
 	// NOEXEC will not allow execution of any binaries on the mounted file system.
-	NOEXEC = C.MNT_NOEXEC
+	NOEXEC = unix.MNT_NOEXEC
 
 	// SYNCHRONOUS will allow any I/O to the file system to be done synchronously.
-	SYNCHRONOUS = C.MNT_SYNCHRONOUS
+	SYNCHRONOUS = unix.MNT_SYNCHRONOUS
 
 	// NOATIME will not update the file access time when reading from a file.
-	NOATIME = C.MNT_NOATIME
+	NOATIME = unix.MNT_NOATIME
 )
 
 // These flags are unsupported.

--- a/mount/flags_unsupported.go
+++ b/mount/flags_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!freebsd freebsd,!cgo
+// +build !linux,!freebsd
 
 package mount
 

--- a/mount/go.mod
+++ b/mount/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/moby/sys/mountinfo v0.1.0
-	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
+	golang.org/x/sys v0.0.0-20200922070232-aee5d888a860
 )

--- a/mount/go.sum
+++ b/mount/go.sum
@@ -1,4 +1,4 @@
 github.com/moby/sys/mountinfo v0.1.0 h1:r8vMRbMAFEAfiNptYVokP+nfxPJzvRuia5e2vzXtENo=
 github.com/moby/sys/mountinfo v0.1.0/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200922070232-aee5d888a860 h1:YEu4SMq7D0cmT7CBbXfcH0NZeuChAXwsHe/9XueUO6o=
+golang.org/x/sys v0.0.0-20200922070232-aee5d888a860/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Bump `golang.org/x/sys/unix` to the latest version and use the `MNT_*`
constants defined there instead of getting them from `sys/mount.h` using
cgo.

Full diff for the `golang.org/x/sys/unix` bump: https://github.com/golang/sys/compare/d5e6a3e2c0ae...aee5d888a86055dc6ab0342f9cdc7b53aaeaec62