### PR TITLE
Make GetMountsFromReader linux-only

### DIFF
--- a/mountinfo/mountinfo.go
+++ b/mountinfo/mountinfo.go
@@ -1,7 +1,6 @@
 package mountinfo
 
 import (
-	"io"
 	"os"
 )
 
@@ -9,14 +8,6 @@ import (
 // with an optional filter applied (use nil for no filter).
 func GetMounts(f FilterFunc) ([]*Info, error) {
 	return parseMountTable(f)
-}
-
-// GetMountsFromReader retrieves a list of mounts from the
-// reader provided, with an optional filter applied (use nil
-// for no filter). This can be useful in tests or benchmarks
-// that provide a fake mountinfo data.
-func GetMountsFromReader(reader io.Reader, f FilterFunc) ([]*Info, error) {
-	return parseInfoFile(reader, f)
 }
 
 // Mounted determines if a specified path is a mount point.

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -11,6 +11,14 @@ import (
 	"strings"
 )
 
+// GetMountsFromReader retrieves a list of mounts from the
+// reader provided, with an optional filter applied (use nil
+// for no filter). This can be useful in tests or benchmarks
+// that provide a fake mountinfo data.
+func GetMountsFromReader(reader io.Reader, f FilterFunc) ([]*Info, error) {
+	return parseInfoFile(reader, f)
+}
+
 func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 	s := bufio.NewScanner(r)
 	out := []*Info{}

--- a/mountinfo/mountinfo_unsupported.go
+++ b/mountinfo/mountinfo_unsupported.go
@@ -4,7 +4,6 @@ package mountinfo
 
 import (
 	"fmt"
-	"io"
 	"runtime"
 )
 
@@ -12,10 +11,6 @@ var errNotImplemented = fmt.Errorf("not implemented on %s/%s", runtime.GOOS, run
 
 func parseMountTable(_ FilterFunc) ([]*Info, error) {
 	return nil, errNotImplemented
-}
-
-func parseInfoFile(_ io.Reader, f FilterFunc) ([]*Info, error) {
-	return parseMountTable(f)
 }
 
 func mounted(path string) (bool, error) {

--- a/mountinfo/mountinfo_windows.go
+++ b/mountinfo/mountinfo_windows.go
@@ -1,14 +1,8 @@
 package mountinfo
 
-import "io"
-
 func parseMountTable(_ FilterFunc) ([]*Info, error) {
 	// Do NOT return an error!
 	return nil, nil
-}
-
-func parseInfoFile(_ io.Reader, f FilterFunc) ([]*Info, error) {
-	return parseMountTable(f)
 }
 
 func mounted(_ string) (bool, error) {


### PR DESCRIPTION
closes https://github.com/moby/sys/pull/35

GetMountsFromReader was a wrapper for parseInfoFile on Linux.
All other implementations do not parse `mountinfo`, so had to
stub out the implemetation and omit the actual reader.

(worse, a FreeBSD implementation was missing, causing compile on
that to fail).

This patch makes GetMountsFromReader linux-only, as it was added
to allow benchmarking the `mountinfo` parsing, which only makes
sense on Linux.
