### PR TITLE
mountinfo: rename FstypeFilter -> FSTypeFilter

### DIFF
--- a/mountinfo/mountinfo_filters.go
+++ b/mountinfo/mountinfo_filters.go
@@ -7,8 +7,8 @@ import "strings"
 // and/or stop further processing if we found what we wanted.
 //
 // It takes a pointer to the Info struct (not fully populated,
-// currently only Mountpoint, Fstype, Source, and (on Linux)
-// VfsOpts are filled in), and returns two booleans:
+// currently only Mountpoint, FSType, Source, and (on Linux)
+// VFSOptions are filled in), and returns two booleans:
 //
 //  - skip: true if the entry should be skipped
 //  - stop: true if parsing should be stopped after the entry

--- a/mountinfo/mountinfo_filters.go
+++ b/mountinfo/mountinfo_filters.go
@@ -45,8 +45,8 @@ func ParentsFilter(path string) FilterFunc {
 	}
 }
 
-// FstypeFilter returns all entries that match provided fstype(s).
-func FstypeFilter(fstype ...string) FilterFunc {
+// FSTypeFilter returns all entries that match provided fstype(s).
+func FSTypeFilter(fstype ...string) FilterFunc {
 	return func(m *Info) (bool, bool) {
 		for _, t := range fstype {
 			if m.FSType == t {

--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -549,8 +549,8 @@ func TestParseMountinfoFilters(t *testing.T) {
 		{PrefixFilter("nonexistent"), 0},
 		// 4 entries: /sys/fs/cgroup/cpu,cpuacct /sys/fs/cgroup /sys /
 		{ParentsFilter("/sys/fs/cgroup/cpu,cpuacct"), 4},
-		{FstypeFilter("pstore"), 1},
-		{FstypeFilter("proc", "sysfs"), 2},
+		{FSTypeFilter("pstore"), 1},
+		{FSTypeFilter("proc", "sysfs"), 2},
 	}
 
 	var r bytes.Reader


### PR DESCRIPTION
This is a followup to #34.

Rename FstypeFilter -> FSTypeFilter.

Also, fix the FilterFunc doc.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>