### PR TITLE
mount.RecursiveUnmount(): minor improvements

### DIFF
--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -69,7 +69,10 @@ func RecursiveUnmount(target string) error {
 		err = Unmount(m.Mountpoint)
 		if err != nil {
 			if i == lastMount {
-				return fmt.Errorf("%w (possible cause: %s)", err, suberr)
+				if suberr != nil {
+					return fmt.Errorf("%w (possible cause: %s)", err, suberr)
+				}
+				return err
 			}
 			// This is a submount, we can ignore the error for now,
 			// the final unmount will fail if this is a real problem.

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -61,11 +61,14 @@ func RecursiveUnmount(target string) error {
 		return len(mounts[i].Mountpoint) > len(mounts[j].Mountpoint)
 	})
 
-	var suberr error
+	var (
+		suberr    error
+		lastMount = len(mounts) - 1
+	)
 	for i, m := range mounts {
 		err = Unmount(m.Mountpoint)
 		if err != nil {
-			if i == len(mounts)-1 { // last mount
+			if i == lastMount {
 				return fmt.Errorf("%w (possible cause: %s)", err, suberr)
 			}
 			// This is a submount, we can ignore the error for now,


### PR DESCRIPTION
- calculate "last mount" outside of the loop
- omit empty "sub-errors" in error message
