### PR TITLE
mountinfo: deprecate PidMountInfo

### DIFF
--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -148,9 +148,14 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 	return GetMountsFromReader(f, filter)
 }
 
-// PidMountInfo collects the mounts for a specific process ID. If the process
-// ID is unknown, it is better to use `GetMounts` which will inspect
-// "/proc/self/mountinfo" instead.
+// PidMountInfo retrieves the list of mounts from a given process' mount
+// namespace. Unless there is a need to get mounts from a mount namespace
+// different from that of a calling process, use GetMounts.
+//
+// This function is Linux-specific.
+//
+// Deprecated: this will be removed before v1; use GetMountsFromReader with
+// opened /proc/<pid>/mountinfo as an argument instead.
 func PidMountInfo(pid int) ([]*Info, error) {
 	f, err := os.Open(fmt.Sprintf("/proc/%d/mountinfo", pid))
 	if err != nil {


### PR DESCRIPTION
Function PidMountInfo is not named correctly (it should be PID not Pid,
and we already have mountinfo in the package name so it's tautological),
and can not accept FilterFunc.

Besides, there are not too many users of this function (I was only able
to found one, see [1]) and users can switch to GetMountsFromReader.

Depreate this function. The plan is to remove it before v1.0.

[1] https://github.com/DataDog/datadog-agent/pull/6495/commits/406d98801434dedc87cab6195079f735d6903d48