### PR TITLE
mountinfo: doc fixes

### DIFF
--- a/mountinfo/doc.go
+++ b/mountinfo/doc.go
@@ -15,11 +15,8 @@
 // parse filters while reading mountinfo. A filter can skip some entries, or stop
 // processing the rest of the file once the needed information is found.
 //
-// For mountinfo filters that accept path as an argument, the path must be:
-//  - absolute;
-//  - having all symlinks resolved;
-//  - being cleaned.
-//
+// For mountinfo filters that accept path as an argument, the path must be absolute,
+// having all symlinks resolved, and being cleaned (i.e. no extra slashes or dots).
 // One way to achieve all of the above is to employ filepath.Abs followed by
 // filepath.EvalSymlinks (the latter calls filepath.Clean on the result so
 // there is no need to explicitly call filepath.Clean).
@@ -28,20 +25,20 @@
 // of the cases where mountinfo should not be parsed:
 //
 // 1. Before performing a mount. Usually, this is not needed, but if required (say to
-//    prevent over-mounts), to check whether a directory is mounted, call os.Lstat
-//    on it and its parent directory, and compare their st.Sys().(*syscall.Stat_t).Dev
-//    fields -- if they differ, then the directory is the mount point. NOTE this does
-//    not work for bind mounts. Optionally, the filesystem type can also be checked
-//    by calling unix.Statfs and checking the Type field (i.e. filesystem type).
+// prevent over-mounts), to check whether a directory is mounted, call os.Lstat
+// on it and its parent directory, and compare their st.Sys().(*syscall.Stat_t).Dev
+// fields -- if they differ, then the directory is the mount point. NOTE this does
+// not work for bind mounts. Optionally, the filesystem type can also be checked
+// by calling unix.Statfs and checking the Type field (i.e. filesystem type).
 //
 // 2. After performing a mount. If there is no error returned, the mount succeeded;
-//    checking the mount table for a new mount is redundant and expensive.
+// checking the mount table for a new mount is redundant and expensive.
 //
 // 3. Before performing an unmount. It is more efficient to do an unmount and ignore
-//    a specific error (EINVAL) which tells the directory is not mounted.
+// a specific error (EINVAL) which tells the directory is not mounted.
 //
 // 4. After performing an unmount. If there is no error returned, the unmount succeeded.
 //
 // 5. To find the mount point root of a specific directory. You can perform os.Stat()
-//    on the directory and traverse up until the Dev field of a parent directory differs.
+// on the directory and traverse up until the Dev field of a parent directory differs.
 package mountinfo

--- a/mountinfo/mountinfo_filters.go
+++ b/mountinfo/mountinfo_filters.go
@@ -10,8 +10,9 @@ import "strings"
 // currently only Mountpoint, FSType, Source, and (on Linux)
 // VFSOptions are filled in), and returns two booleans:
 //
-//  - skip: true if the entry should be skipped
-//  - stop: true if parsing should be stopped after the entry
+// skip: true if the entry should be skipped;
+//
+// stop: true if parsing should be stopped after the entry.
 type FilterFunc func(*Info) (skip, stop bool)
 
 // PrefixFilter discards all entries whose mount points
@@ -36,8 +37,8 @@ func SingleEntryFilter(mp string) FilterFunc {
 // ParentsFilter returns all entries whose mount points
 // can be parents of a path specified, discarding others.
 //
-// For example, given `/var/lib/docker/something`, entries
-// like `/var/lib/docker`, `/var` and `/` are returned.
+// For example, given /var/lib/docker/something, entries
+// like /var/lib/docker, /var and / are returned.
 func ParentsFilter(path string) FilterFunc {
 	return func(m *Info) (bool, bool) {
 		skip := !strings.HasPrefix(path, m.Mountpoint)


### PR DESCRIPTION
1. Lines that start with a space are treated as verbatim text
   (rendered as \<pre\> in HTML). Fix those.

2. There is no sense in having github markdown (like `var`).

This was inspired by the way it looks right now:
* https://pkg.go.dev/github.com/moby/sys/mountinfo@v0.3.1