### PR TITLE
mountinfo: correctness improvements

### DIFF
--- a/mountinfo/mountinfo_filters.go
+++ b/mountinfo/mountinfo_filters.go
@@ -6,9 +6,8 @@ import "strings"
 // used to filter out mountinfo entries we're not interested in,
 // and/or stop further processing if we found what we wanted.
 //
-// It takes a pointer to the Info struct (not fully populated,
-// currently only Mountpoint, FSType, Source, and (on Linux)
-// VFSOptions are filled in), and returns two booleans:
+// It takes a pointer to the Info struct (fully populated with all available
+// fields on the GOOS platform), and returns two booleans:
 //
 // skip: true if the entry should be skipped;
 //

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -18,11 +18,9 @@ import (
 func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 	s := bufio.NewScanner(r)
 	out := []*Info{}
-	var err error
 	for s.Scan() {
-		if err = s.Err(); err != nil {
-			return nil, err
-		}
+		var err error
+
 		/*
 		   See http://man7.org/linux/man-pages/man5/proc.5.html
 
@@ -132,6 +130,9 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		if stop {
 			break
 		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -477,6 +477,33 @@ func TestParseFedoraMountinfoFields(t *testing.T) {
 	}
 }
 
+func TestParseFedoraMountinfoFilterFields(t *testing.T) {
+	r := bytes.NewBuffer([]byte(fedoraMountinfo))
+	_, err := GetMountsFromReader(r, func(info *Info) (skip bool, stop bool) {
+		mi := Info{
+			ID:         15,
+			Parent:     35,
+			Major:      0,
+			Minor:      3,
+			Root:       "/",
+			Mountpoint: "/proc",
+			Options:    "rw,nosuid,nodev,noexec,relatime",
+			Optional:   "shared:5",
+			FSType:     "proc",
+			Source:     "proc",
+			VFSOptions: "rw",
+		}
+		if *info != mi {
+			t.Fatalf("expected %#v, got %#v", mi, *info)
+		}
+		// Only match the first entry as in TestParseFedoraMountinfoFields.
+		return false, true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestParseMountinfoWithSpaces(t *testing.T) {
 	r := bytes.NewBuffer([]byte(mountInfoWithSpaces))
 	infos, err := GetMountsFromReader(r, nil)


### PR DESCRIPTION
This fixes two correctness issues with mountinfo (one of which caused opencontainers/runc#2647 to be a security regression):

 * Correctly handle IO errors during scanning.
 * Run the filter function after all fields are parsed.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>