### PR TITLE
mountinfo: docs nits

### DIFF
--- a/mountinfo/mountinfo.go
+++ b/mountinfo/mountinfo.go
@@ -29,35 +29,38 @@ type Info struct {
 	// ID is a unique identifier of the mount (may be reused after umount).
 	ID int
 
-	// Parent indicates the ID of the mount parent (or of self for the top of the
-	// mount tree).
+	// Parent is the ID of the parent mount (or of self for the root
+	// of this mount namespace's mount tree).
 	Parent int
 
-	// Major indicates one half of the device ID which identifies the device class.
-	Major int
+	// Major and Minor are the major and the minor components of the Dev
+	// field of unix.Stat_t structure returned by unix.*Stat calls for
+	// files on this filesystem.
+	Major, Minor int
 
-	// Minor indicates one half of the device ID which identifies a specific
-	// instance of device.
-	Minor int
-
-	// Root of the mount within the filesystem.
+	// Root is the pathname of the directory in the filesystem which forms
+	// the root of this mount.
 	Root string
 
-	// Mountpoint indicates the mount point relative to the process's root.
+	// Mountpoint is the pathname of the mount point relative to the
+	// process's root directory.
 	Mountpoint string
 
-	// Options represents mount-specific options.
+	// Options is a comma-separated list of mount options.
 	Options string
 
-	// Optional represents optional fields.
+	// Optional are zero or more fields of the form "tag[:value]",
+	// separated by a space.  Currently, the possible optional fields are
+	// "shared", "master", "propagate_from", and "unbindable". For more
+	// information, see mount_namespaces(7) Linux man page.
 	Optional string
 
-	// FSType indicates the type of filesystem, such as EXT3.
+	// FSType is the filesystem type in the form "type[.subtype]".
 	FSType string
 
-	// Source indicates filesystem specific information or "none".
+	// Source is filesystem-specific information, or "none".
 	Source string
 
-	// VFSOptions represents per super block options.
+	// VFSOptions is a comma-separated list of superblock options.
 	VFSOptions string
 }

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -12,7 +12,8 @@ import (
 // GetMountsFromReader retrieves a list of mounts from the
 // reader provided, with an optional filter applied (use nil
 // for no filter). This can be useful in tests or benchmarks
-// that provide a fake mountinfo data.
+// that provide fake mountinfo data, or when a source other
+// than /proc/self/mountinfo needs to be read from.
 //
 // This function is Linux-specific.
 func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
@@ -133,8 +134,6 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 	return out, nil
 }
 
-// Parse /proc/self/mountinfo because comparing Dev and ino does not work from
-// bind mounts
 func parseMountTable(filter FilterFunc) ([]*Info, error) {
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {


### PR DESCRIPTION
###    mountinfo: docs nits
    
1. Add a "custom file" use case to GetMountsFromReader.
    
2. Remove obsoleted old comment from parseMountTable.

### mountinfo.Info: refresh doc
    
Refresh documentation about mountinfo.Info fields, based on the latest
proc(5) from man-pages v5.08.