### PR TITLE
symlink: drop go 1.13, and use testing.Cleanup()

### DIFF
--- a/symlink/fs_unix_test.go
+++ b/symlink/fs_unix_test.go
@@ -53,8 +53,8 @@ func testSymlink(tmpdir, path, expected, scope string) error {
 }
 
 func TestFollowSymlinkAbsolute(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
+
 	if err := makeFs(tmpdir, []dirOrLink{{path: "testdata/fs/a/d", target: "/b"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -64,8 +64,7 @@ func TestFollowSymlinkAbsolute(t *testing.T) {
 }
 
 func TestFollowSymlinkRelativePath(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{{path: "testdata/fs/i", target: "a"}}); err != nil {
 		t.Fatal(err)
@@ -76,8 +75,7 @@ func TestFollowSymlinkRelativePath(t *testing.T) {
 }
 
 func TestFollowSymlinkSkipSymlinksOutsideScope(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{
 		{path: "linkdir", target: "realdir"},
@@ -97,8 +95,7 @@ func TestFollowSymlinkInvalidScopePathPair(t *testing.T) {
 }
 
 func TestFollowSymlinkLastLink(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{{path: "testdata/fs/a/d", target: "/b"}}); err != nil {
 		t.Fatal(err)
@@ -109,8 +106,7 @@ func TestFollowSymlinkLastLink(t *testing.T) {
 }
 
 func TestFollowSymlinkRelativeLinkChangeScope(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{{path: "testdata/fs/a/e", target: "../b"}}); err != nil {
 		t.Fatal(err)
@@ -126,8 +122,7 @@ func TestFollowSymlinkRelativeLinkChangeScope(t *testing.T) {
 }
 
 func TestFollowSymlinkDeepRelativeLinkChangeScope(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{{path: "testdata/fs/a/f", target: "../../../../test"}}); err != nil {
 		t.Fatal(err)
@@ -147,8 +142,7 @@ func TestFollowSymlinkDeepRelativeLinkChangeScope(t *testing.T) {
 }
 
 func TestFollowSymlinkRelativeLinkChain(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	// avoid letting symlink g (pointed at by symlink h) take out of scope
 	// TODO: we should probably normalize to scope here because ../[....]/root
@@ -165,8 +159,7 @@ func TestFollowSymlinkRelativeLinkChain(t *testing.T) {
 }
 
 func TestFollowSymlinkBreakoutPath(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	// avoid letting symlink -> ../directory/file escape from scope
 	// normalize to "testdata/fs/j"
@@ -179,8 +172,7 @@ func TestFollowSymlinkBreakoutPath(t *testing.T) {
 }
 
 func TestFollowSymlinkToRoot(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	// make sure we don't allow escaping to /
 	// normalize to dir
@@ -193,8 +185,7 @@ func TestFollowSymlinkToRoot(t *testing.T) {
 }
 
 func TestFollowSymlinkSlashDotdot(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 	tmpdir = filepath.Join(tmpdir, "dir", "subdir")
 
 	// make sure we don't allow escaping to /
@@ -208,8 +199,7 @@ func TestFollowSymlinkSlashDotdot(t *testing.T) {
 }
 
 func TestFollowSymlinkDotdot(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 	tmpdir = filepath.Join(tmpdir, "dir", "subdir")
 
 	// make sure we stay in scope without leaking information
@@ -224,8 +214,7 @@ func TestFollowSymlinkDotdot(t *testing.T) {
 }
 
 func TestFollowSymlinkRelativePath2(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{{path: "bar/foo", target: "baz/target"}}); err != nil {
 		t.Fatal(err)
@@ -236,8 +225,7 @@ func TestFollowSymlinkRelativePath2(t *testing.T) {
 }
 
 func TestFollowSymlinkScopeLink(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{
 		{path: "root2"},
@@ -252,8 +240,7 @@ func TestFollowSymlinkScopeLink(t *testing.T) {
 }
 
 func TestFollowSymlinkRootScope(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	expected, err := filepath.EvalSymlinks(tmpdir)
 	if err != nil {
@@ -283,8 +270,7 @@ func TestFollowSymlinkEmpty(t *testing.T) {
 }
 
 func TestFollowSymlinkCircular(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{{path: "root/foo", target: "foo"}}); err != nil {
 		t.Fatal(err)
@@ -306,8 +292,7 @@ func TestFollowSymlinkCircular(t *testing.T) {
 }
 
 func TestFollowSymlinkComplexChainWithTargetPathsContainingLinks(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{
 		{path: "root2"},
@@ -327,8 +312,7 @@ func TestFollowSymlinkComplexChainWithTargetPathsContainingLinks(t *testing.T) {
 }
 
 func TestFollowSymlinkBreakoutNonExistent(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{
 		{path: "root/slash", target: "/"},
@@ -342,8 +326,7 @@ func TestFollowSymlinkBreakoutNonExistent(t *testing.T) {
 }
 
 func TestFollowSymlinkNoLexicalCleaning(t *testing.T) {
-	tmpdir, cleanup := mkTempDir(t)
-	defer cleanup()
+	tmpdir := mkTempDir(t)
 
 	if err := makeFs(tmpdir, []dirOrLink{
 		{path: "root/sym", target: "/foo/bar"},
@@ -356,11 +339,14 @@ func TestFollowSymlinkNoLexicalCleaning(t *testing.T) {
 	}
 }
 
-func mkTempDir(t *testing.T) (string, func()) {
+// TODO use testing.TempDir() instead (https://golang.org/pkg/testing/#T.TempDir)
+//      once we no longer test on Go 1.14 and older.
+func mkTempDir(t *testing.T) string {
 	t.Helper()
 	tmpdir, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	return tmpdir, func() { _ = os.RemoveAll(tmpdir) }
+	t.Cleanup(func() { _ = os.RemoveAll(tmpdir) })
+	return tmpdir
 }

--- a/symlink/go.mod
+++ b/symlink/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/symlink
 
-go 1.13
+go 1.14
 
 require golang.org/x/sys v0.0.0-20200922070232-aee5d888a860


### PR DESCRIPTION
Cleanup was added in Go 1.14, so we need to drop go 1.13 for this.
