### PR TITLE
Create proper mounter for OpenBSD

### DIFF
--- a/mount/mounter_freebsd.go
+++ b/mount/mounter_freebsd.go
@@ -1,4 +1,4 @@
-// +build freebsd,cgo openbsd,cgo
+// +build freebsd,cgo
 
 package mount
 

--- a/mount/mounter_openbsd.go
+++ b/mount/mounter_openbsd.go
@@ -1,0 +1,77 @@
+// +build openbsd,cgo
+
+/*
+   Due to how OpenBSD mount(2) works, filesystem types need to be
+   supported explicitly since it uses separate structs to pass
+   filesystem-specific arguments.
+
+   For now only UFS/FFS is supported as it's the default fs
+   on OpenBSD systems.
+
+   See: https://man.openbsd.org/mount.2
+*/
+
+package mount
+
+/*
+#include <sys/types.h>
+#include <sys/mount.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+func createExportInfo(readOnly bool) C.struct_export_args {
+	exportFlags := C.int(0)
+	if readOnly {
+		exportFlags = C.MNT_EXRDONLY
+	}
+	out := C.struct_export_args{
+		ex_root:  0,
+		ex_flags: exportFlags,
+	}
+	return out
+}
+
+func createUfsArgs(device string, readOnly bool) unsafe.Pointer {
+	out := &C.struct_ufs_args{
+		fspec:       C.CString(device),
+		export_info: createExportInfo(readOnly),
+	}
+	return unsafe.Pointer(out)
+}
+
+func mount(device, target, mType string, flag uintptr, data string) error {
+	readOnly := flag&RDONLY != 0
+
+	var fsArgs unsafe.Pointer
+
+	switch mType {
+	case "ffs":
+		fsArgs = createUfsArgs(device, readOnly)
+	default:
+		return &mountError{
+			op:     "mount",
+			source: device,
+			target: target,
+			flags:  flag,
+			err:    fmt.Errorf("unsupported file system type: %s", mType),
+		}
+	}
+
+	if errno := C.mount(C.CString(mType), C.CString(target), C.int(flag), fsArgs); errno != 0 {
+		return &mountError{
+			op:     "mount",
+			source: device,
+			target: target,
+			flags:  flag,
+			err:    syscall.Errno(errno),
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is made for the sysutils/docker-cli port which I maintain, as moby/sys is part of the vendored libraries for docker/cli.

While I could stub this out (the same way as how it is on darwin and windows), I decided to actually write a proper mounter since it seems there's intention to actually bring OpenBSD support (as seen in https://github.com/moby/sys/commit/cb807b1e4cf01065587739df73d758d6d171819b).

OpenBSD's [mount(2)](https://man.openbsd.org/mount.2) works differently since it uses separate structs to present options for different filesystems, unlike in FreeBSD. It also means that support for other filesystems need to be added explicitly. I'm not sure which ones are required for now so I just write support for only FFS, which is the go-to filesystem used by OpenBSD systems.