### PR TITLE
mountinfo: fix PrefixFilter() being too greedy

### DIFF
--- a/mountinfo/mountinfo_filters.go
+++ b/mountinfo/mountinfo_filters.go
@@ -14,11 +14,16 @@ import "strings"
 // stop: true if parsing should be stopped after the entry.
 type FilterFunc func(*Info) (skip, stop bool)
 
-// PrefixFilter discards all entries whose mount points
-// do not start with a specific prefix.
+// PrefixFilter discards all entries whose mount points do not start with, or
+// are equal to the path specified in prefix. The prefix path must be absolute,
+// have all symlinks resolved, and cleaned (i.e. no extra slashes or dots).
+//
+// PrefixFilter treats prefix as a path, not a partial prefix, which means that
+// given "/foo", "/foo/bar" and "/foobar" entries, PrefixFilter("/foo") returns
+// "/foo" and "/foo/bar", and discards "/foobar".
 func PrefixFilter(prefix string) FilterFunc {
 	return func(m *Info) (bool, bool) {
-		skip := !strings.HasPrefix(m.Mountpoint, prefix)
+		skip := !strings.HasPrefix(m.Mountpoint+"/", prefix+"/")
 		return skip, false
 	}
 }

--- a/mountinfo/mountinfo_filters_test.go
+++ b/mountinfo/mountinfo_filters_test.go
@@ -1,0 +1,31 @@
+package mountinfo
+
+import "testing"
+
+func TestPrefixFilter(t *testing.T) {
+	tests := []struct {
+		prefix     string
+		mountPoint string
+		shouldSkip bool
+	}{
+		{prefix: "/a", mountPoint: "/a", shouldSkip: false},
+		{prefix: "/a", mountPoint: "/a/b", shouldSkip: false},
+		{prefix: "/a", mountPoint: "/aa", shouldSkip: true},
+		{prefix: "/a", mountPoint: "/aa/b", shouldSkip: true},
+
+		// invalid prefix: prefix path must be cleaned and have no trailing slash
+		{prefix: "/a/", mountPoint: "/a", shouldSkip: true},
+		{prefix: "/a/", mountPoint: "/a/b", shouldSkip: true},
+	}
+	for _, tc := range tests {
+		filter := PrefixFilter(tc.prefix)
+		skip, _ := filter(&Info{Mountpoint: tc.mountPoint})
+		if skip != tc.shouldSkip {
+			if tc.shouldSkip {
+				t.Errorf("prefix %q: expected %q to be skipped", tc.prefix, tc.mountPoint)
+			} else {
+				t.Errorf("prefix %q: expected %q not to be skipped", tc.prefix, tc.mountPoint)
+			}
+		}
+	}
+}


### PR DESCRIPTION
The PrefixFilter matched on a literal "prefix", making it too greedy, and,
for example, filtering on "/a" prefix would also return mounts for
"/aaa" or "/abc".

This patch changes the matching to match on a prefix / parent _path_ instead.
