### PR TITLE
mount: add exec and noexec as valid flags to mount options

### DIFF
--- a/mount/mounter_linux_test.go
+++ b/mount/mounter_linux_test.go
@@ -47,6 +47,8 @@ func TestMount(t *testing.T) {
 	}{
 		// No options
 		{"tmpfs", "tmpfs", "", "", "", ""},
+		// tmpfs mount with noexec set
+		{"tmpfs", "tmpfs", "noexec", "noexec", "", ""},
 		// Default rw / ro test
 		{source, "", "bind", "", "", ""},
 		{source, "", "bind,private", "", "", ""},


### PR DESCRIPTION
Carrying the pkg/mount changes from https://github.com/moby/moby/pull/36720