### PR TITLE
mount: also test against local mountinfo source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/mount/go-local.*


### PR DESCRIPTION
mount depends on mountinfo, but defaults to the release specified in go.mod.

This change adds a new test to also run against the local code so that we can catch regressions / breaking changes.
