### PR TITLE
migrate github.com/docker/docker/pkg/signal (take 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .SHELLFLAGS = -ec
-PACKAGES ?= mountinfo mount symlink
+PACKAGES ?= mountinfo mount signal symlink
 BINDIR ?= _build/bin
 CROSS ?= linux/arm linux/arm64 linux/ppc64le linux/s390x \
 	freebsd/amd64 openbsd/amd64 darwin/amd64 darwin/arm64 windows/amd64

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -1,0 +1,5 @@
+module github.com/moby/sys/signal
+
+go 1.13
+
+require golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c

--- a/signal/go.sum
+++ b/signal/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -1,6 +1,6 @@
 // Package signal provides helper functions for dealing with signals across
 // various operating systems.
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"fmt"

--- a/signal/signal_darwin.go
+++ b/signal/signal_darwin.go
@@ -1,4 +1,4 @@
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"syscall"

--- a/signal/signal_freebsd.go
+++ b/signal/signal_freebsd.go
@@ -1,4 +1,4 @@
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"syscall"

--- a/signal/signal_linux.go
+++ b/signal/signal_linux.go
@@ -1,6 +1,6 @@
 // +build !mips,!mipsle,!mips64,!mips64le
 
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"syscall"

--- a/signal/signal_linux_mipsx.go
+++ b/signal/signal_linux_mipsx.go
@@ -1,7 +1,7 @@
 // +build linux
 // +build mips mipsle mips64 mips64le
 
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"syscall"

--- a/signal/signal_linux_test.go
+++ b/signal/signal_linux_test.go
@@ -1,6 +1,6 @@
 // +build darwin linux
 
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"os"

--- a/signal/signal_test.go
+++ b/signal/signal_test.go
@@ -1,4 +1,4 @@
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"syscall"

--- a/signal/signal_unix.go
+++ b/signal/signal_unix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"syscall"

--- a/signal/signal_unsupported.go
+++ b/signal/signal_unsupported.go
@@ -1,6 +1,6 @@
 // +build !linux,!darwin,!freebsd,!windows
 
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"syscall"

--- a/signal/signal_windows.go
+++ b/signal/signal_windows.go
@@ -1,4 +1,4 @@
-package signal // import "github.com/docker/docker/pkg/signal"
+package signal
 
 import (
 	"syscall"


### PR DESCRIPTION
same as https://github.com/moby/sys/pull/69, but from https://github.com/moby/moby/pull/42641 (not yet merged)

relates to https://github.com/containerd/containerd/issues/5402


Migrating this package from commit (https://github.com/moby/moby/pull/42641):
https://github.com/docker/docker/commit/9a6ff685a80639995311c0572d662360b55796d9

Strategy taken:

    # install filter-repo (https://github.com/newren/git-filter-repo/blob/main/INSTALL.md)
    brew install git-filter-repo

    cd ~/projects

    # create a temporary clone of docker
    git clone https://github.com/docker/docker.git moby_signal
    cd moby_signal

    # remove all code, except for pkg/signal, and rename to /signal
    git filter-repo  --path pkg/signal --path-rename pkg/signal:signal

    # exclude the _deprecated.go and README.md
    git filter-repo --path-glob 'signal/*.md' --path-glob 'signal/*_deprecated.go' --invert-paths

    # go to the target github.com/moby/sys repository
    cd ~/projects/moby-sys

    # create a branch to work with
    git checkout -b integrate_moby_signal_take2

    # add the temporary repository as an upstream and make sure it's up-to-date
    git remote add moby_signal ~/projects/moby_signal
    git fetch moby_signal

    # merge the upstream code
    git merge --allow-unrelated-histories --signoff -S moby_signal/master

After this:

- signal: update import-paths
- signal: add go.mod
- Makefile: enable tests for signals
