### PR TITLE
signal: fix name for SIGBUS on darwin

### DIFF
--- a/signal/signal_darwin.go
+++ b/signal/signal_darwin.go
@@ -8,7 +8,7 @@ import (
 var SignalMap = map[string]syscall.Signal{
 	"ABRT":   syscall.SIGABRT,
 	"ALRM":   syscall.SIGALRM,
-	"BUG":    syscall.SIGBUS,
+	"BUS":    syscall.SIGBUS,
 	"CHLD":   syscall.SIGCHLD,
 	"CONT":   syscall.SIGCONT,
 	"EMT":    syscall.SIGEMT,


### PR DESCRIPTION
I noticed that the name for `SIGBUS` on Darwin was mapped to `BUG`. To be sure that a `BUG` signal is not actually a "thing", I looked at the history for this; this mapping was originally added in: https://github.com/docker/docker/commit/10dc16dcd3aa82be256e5072a25dcf18af8e3844 (https://github.com/docker/docker/pull/4563),

Looking at the Darwin headers, I also don't see a mention of a `BUG` signal:
https://github.com/apple/darwin-xnu/blob/b6dbbb99918752ac84da97aa9b473bd974afc609/bsd/sys/signal.h#L98,

So, I'm assuming this was a rather funny slip-up, which makes this a "BUS-FIX" ?
