### PR TITLE
signal: fix name for SIGBUS on freebsd

### DIFF
--- a/signal/signal_freebsd.go
+++ b/signal/signal_freebsd.go
@@ -8,7 +8,7 @@ import (
 var SignalMap = map[string]syscall.Signal{
 	"ABRT":   syscall.SIGABRT,
 	"ALRM":   syscall.SIGALRM,
-	"BUF":    syscall.SIGBUS,
+	"BUS":    syscall.SIGBUS,
 	"CHLD":   syscall.SIGCHLD,
 	"CONT":   syscall.SIGCONT,
 	"EMT":    syscall.SIGEMT,


### PR DESCRIPTION
I'm guessing this was a typo; originally added in:
https://github.com/docker/docker/commit/10dc16dcd3aa82be256e5072a25dcf18af8e3844,

(Assuming the author has a dislike for SIGBUS (or 🚌))
