### PR TITLE
mountinfo.GetMountsFromReader() use strings.SplitN()

### DIFF
--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -90,7 +90,7 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		// ignore any numbers parsing errors, as there should not be any
 		p.ID, _ = strconv.Atoi(fields[0])
 		p.Parent, _ = strconv.Atoi(fields[1])
-		mm := strings.Split(fields[2], ":")
+		mm := strings.SplitN(fields[2], ":", 3)
 		if len(mm) != 2 {
 			return nil, fmt.Errorf("Parsing '%s' failed: unexpected minor:major pair %s", text, mm)
 		}


### PR DESCRIPTION
We expect 2 fields to be there, anything below (or above) will produce
an error, so limit the number of strings we split into to 3. This still
allows us to detect "too many colons", but won't result in splitting
without bounds.
