### PR TITLE
signal: remove DefaultStopSignal

### DIFF
--- a/signal/signal_unix.go
+++ b/signal/signal_unix.go
@@ -16,6 +16,4 @@ const (
 	SIGWINCH = syscall.SIGWINCH
 	// SIGPIPE is a signal sent to a process when a pipe is written to before the other end is open for reading
 	SIGPIPE = syscall.SIGPIPE
-	// DefaultStopSignal is the syscall signal used to stop a container in unix systems.
-	DefaultStopSignal = "SIGTERM"
 )

--- a/signal/signal_windows.go
+++ b/signal/signal_windows.go
@@ -12,8 +12,6 @@ const (
 	SIGCHLD  = syscall.Signal(0xff)
 	SIGWINCH = syscall.Signal(0xff)
 	SIGPIPE  = syscall.Signal(0xff)
-	// DefaultStopSignal is the syscall signal used to stop a container in windows systems.
-	DefaultStopSignal = "15"
 )
 
 // SignalMap is a map of "supported" signals. As per the comment in GOLang's


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/42717

This const was inherited from the Docker/Moby repository, but does not make a lot of sense in the new location.

Removing this const here.
