### PR TITLE
mount: errors should not start with a capital

### DIFF
--- a/mount/flags_unix.go
+++ b/mount/flags_unix.go
@@ -101,7 +101,7 @@ func MergeTmpfsOptions(options []string) ([]string, error) {
 		}
 		opt := strings.SplitN(option, "=", 2)
 		if len(opt) != 2 || !validFlags[opt[0]] {
-			return nil, fmt.Errorf("Invalid tmpfs option %q", opt)
+			return nil, fmt.Errorf("invalid tmpfs option %q", opt)
 		}
 		if !dataCollisions[opt[0]] {
 			// We prepend the option and add to collision map


### PR DESCRIPTION
looks like I missed this one when opening https://github.com/moby/sys/pull/75