### PR TITLE
mountinfo: GetMountsFromReader() remove redundant switch, fix dropped "optional" fields

### DIFF
--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -105,16 +105,9 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		p.Options = fields[5]
 
 		// zero or more optional fields
-		switch {
-		case sepIdx == 6:
-			// zero, do nothing
-		case sepIdx == 7:
-			p.Optional = fields[6]
-		default:
-			p.Optional = strings.Join(fields[6:sepIdx-1], " ")
-		}
+		p.Optional = strings.Join(fields[6:sepIdx], " ")
 
-		// Run the filter after parsing all of the fields.
+		// Run the filter after parsing all fields.
 		var skip, stop bool
 		if filter != nil {
 			skip, stop = filter(p)

--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -676,7 +676,7 @@ func TestParseMountinfoExtraCases(t *testing.T) {
 			name:  "one optional field",
 			entry: `251 15 0:3573 / /mnt/point rw,relatime shared:123 - aufs none rw`,
 			valid: true,
-			exp:   &Info{Mountpoint: "/mnt/point", FSType: "aufs", Source: "none", Optional: "shared:123 extra:tag what:ever"},
+			exp:   &Info{Mountpoint: "/mnt/point", FSType: "aufs", Source: "none", Optional: "shared:123"},
 		},
 		{
 			name:  "extra optional fields", // which we carefully gather
@@ -722,6 +722,9 @@ func TestParseMountinfoExtraCases(t *testing.T) {
 			}
 			if tc.exp.Source != "" && tc.exp.Source != i.Source {
 				t.Errorf("expected src %s, got %s", tc.exp.Source, i.Source)
+			}
+			if tc.exp.Optional != "" && tc.exp.Optional != i.Optional {
+				t.Errorf("expected optional %s, got %s", tc.exp.Optional, i.Optional)
 			}
 		})
 	}

--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -682,7 +682,7 @@ func TestParseMountinfoExtraCases(t *testing.T) {
 			name:  "extra optional fields", // which we carefully gather
 			entry: `251 15 0:3573 / /mnt/point rw,relatime shared:123 extra:tag what:ever key:value - aufs none rw`,
 			valid: true,
-			exp:   &Info{Mountpoint: "/mnt/point", FSType: "aufs", Source: "none", Optional: "shared:123 extra:tag what:ever"},
+			exp:   &Info{Mountpoint: "/mnt/point", FSType: "aufs", Source: "none", Optional: "shared:123 extra:tag what:ever key:value"},
 		},
 		{
 			name:  "empty source field (kernel < 5.1 bug)",

--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -693,34 +693,37 @@ func TestParseMountinfoExtraCases(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		r := bytes.NewBufferString(tc.entry)
-		info, err := GetMountsFromReader(r, nil)
-		if !tc.valid {
-			if err == nil {
-				t.Errorf("case %q: expected error, got nil", tc.name)
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			r := bytes.NewBufferString(tc.entry)
+			info, err := GetMountsFromReader(r, nil)
+			if !tc.valid {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
 			}
-			continue
-		}
-		if err != nil {
-			t.Errorf("case %q: expected no error, got %v", tc.name, err)
-			continue
-		}
-		if len(info) != 1 {
-			t.Errorf("case %q: expected 1 result, got %d", tc.name, len(info))
-		}
-		if tc.exp == nil {
-			continue
-		}
-		i := info[0]
-		if tc.exp.Mountpoint != "" && tc.exp.Mountpoint != i.Mountpoint {
-			t.Errorf("case %q: expected mp %s, got %s", tc.name, tc.exp.Mountpoint, i.Mountpoint)
-		}
-		if tc.exp.FSType != "" && tc.exp.FSType != i.FSType {
-			t.Errorf("case %q: expected fs %s, got %s", tc.name, tc.exp.FSType, i.FSType)
-		}
-		if tc.exp.Source != "" && tc.exp.Source != i.Source {
-			t.Errorf("case %q: expected src %s, got %s", tc.name, tc.exp.Source, i.Source)
-		}
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+				return
+			}
+			if len(info) != 1 {
+				t.Errorf("expected 1 result, got %d", len(info))
+			}
+			if tc.exp == nil {
+				return
+			}
+			i := info[0]
+			if tc.exp.Mountpoint != "" && tc.exp.Mountpoint != i.Mountpoint {
+				t.Errorf("expected mp %s, got %s", tc.exp.Mountpoint, i.Mountpoint)
+			}
+			if tc.exp.FSType != "" && tc.exp.FSType != i.FSType {
+				t.Errorf("expected fs %s, got %s", tc.exp.FSType, i.FSType)
+			}
+			if tc.exp.Source != "" && tc.exp.Source != i.Source {
+				t.Errorf("expected src %s, got %s", tc.exp.Source, i.Source)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This switch was implementing the exact same check as is done in
strings.Join(); https://cs.opensource.google/go/go/+/refs/tags/go1.16.7:src/strings/strings.go;l=421-427

```go
func Join(elems []string, sep string) string {
	switch len(elems) {
	case 0:
		return ""
	case 1:
		return elems[0]
	}
```

This only difference removing this switch makes is that it will assign
an empty string to p.Optional if no optional fields are present, but
given that an empty string is the default value for p.Optional, this
should make no difference.

This also revealed an off-by-one bug:

Before this change:

- we return an error if `sepIdx == 5` (earlier check)
- for `sepIdx == 6` we skipped (in this switch)
- for `7`, we take field 6 (equivalent to `fields[6:7]`, or `fields[6:sepIdx]`)
- for the "default" (else), we use `fields[6:sepIdx-1]`, which for (e.g.) `sepIndex=8`
  would do the same as `sepIdx=7`, so we'd drop one value.
