### PR TITLE
ci/gha: drop go 1.14, add go 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x]
         platform: [ubuntu-20.04, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
go 1.15 is no longer supported, and go 1.14 is not supported since go
1.16 is released (roughly half a year ago).

Let's keep the latest unsupported version (1.15) for now, but drop the
older 1.14.