### PR TITLE
CI: add more linters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Default
+* text=auto
+
+# Go files should always have UNIX-style line endings
+# (see e.g. https://github.com/golang/go/issues/16355)
+*.go	text eol=lf

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,3 +2,4 @@ linters:
   enable:
     - unconvert
     - errorlint
+    - gofumpt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+linters:
+  enable:
+    - unconvert
+    - errorlint

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ lint: $(BINDIR)/golangci-lint
 	done
 
 $(BINDIR)/golangci-lint: $(BINDIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.41.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.43.0
 
 $(BINDIR):
 	mkdir -p $(BINDIR)

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -23,7 +23,7 @@ func Mount(device, target, mType, options string) error {
 // a normal unmount. If target is not a mount point, no error is returned.
 func Unmount(target string) error {
 	err := unix.Unmount(target, mntDetach)
-	if err == nil || err == unix.EINVAL {
+	if err == nil || err == unix.EINVAL { //nolint:errorlint // unix errors are bare
 		// Ignore "not mounted" error here. Note the same error
 		// can be returned if flags are invalid, so this code
 		// assumes that the flags value is always correct.

--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -35,7 +35,7 @@ func TestMounted(t *testing.T) {
 	}
 
 	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0777); err != nil {
+	if err := os.MkdirAll(tmp, 0o777); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
@@ -47,18 +47,18 @@ func TestMounted(t *testing.T) {
 		targetPath = path.Join(targetDir, "file.txt")
 	)
 
-	if err := os.Mkdir(sourceDir, 0777); err != nil {
+	if err := os.Mkdir(sourceDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(targetDir, 0777); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := ioutil.WriteFile(sourcePath, []byte("hello"), 0644); err != nil {
+	if err := os.Mkdir(targetDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(targetPath, nil, 0644); err != nil {
+	if err := ioutil.WriteFile(sourcePath, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(targetPath, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -105,7 +105,7 @@ func TestMountTmpfsOptions(t *testing.T) {
 	}
 
 	target := path.Join(os.TempDir(), "mount-tmpfs-tests-"+t.Name())
-	if err := os.MkdirAll(target, 0777); err != nil {
+	if err := os.MkdirAll(target, 0o777); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(target)
@@ -142,7 +142,7 @@ func TestMountReadonly(t *testing.T) {
 	}
 
 	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0777); err != nil {
+	if err := os.MkdirAll(tmp, 0o777); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
@@ -154,18 +154,18 @@ func TestMountReadonly(t *testing.T) {
 		targetPath = path.Join(targetDir, "file.txt")
 	)
 
-	if err := os.Mkdir(sourceDir, 0777); err != nil {
+	if err := os.Mkdir(sourceDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(targetDir, 0777); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := ioutil.WriteFile(sourcePath, []byte("hello"), 0644); err != nil {
+	if err := os.Mkdir(targetDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(targetPath, nil, 0644); err != nil {
+	if err := ioutil.WriteFile(sourcePath, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(targetPath, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -178,7 +178,7 @@ func TestMountReadonly(t *testing.T) {
 		}
 	}()
 
-	if err := ioutil.WriteFile(targetPath, []byte("hello"), 0644); err == nil {
+	if err := ioutil.WriteFile(targetPath, []byte("hello"), 0o644); err == nil {
 		t.Fatal("Should not be able to open a ro file as rw")
 	}
 }

--- a/mount/mounter_linux.go
+++ b/mount/mounter_linux.go
@@ -65,7 +65,6 @@ func mount(device, target, mType string, flags uintptr, data string) error {
 				flags:  oflags | unix.MS_REMOUNT,
 				err:    err,
 			}
-
 		}
 	}
 

--- a/mount/sharedsubtree_linux_test.go
+++ b/mount/sharedsubtree_linux_test.go
@@ -17,7 +17,7 @@ func TestSubtreePrivate(t *testing.T) {
 	}
 
 	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0777); err != nil {
+	if err := os.MkdirAll(tmp, 0o777); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
@@ -33,19 +33,19 @@ func TestSubtreePrivate(t *testing.T) {
 		outside1CheckPath = path.Join(targetDir, "a", "file.txt")
 		outside2CheckPath = path.Join(sourceDir, "b", "file.txt")
 	)
-	if err := os.MkdirAll(path.Join(sourceDir, "a"), 0777); err != nil {
+	if err := os.MkdirAll(path.Join(sourceDir, "a"), 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(path.Join(sourceDir, "b"), 0777); err != nil {
+	if err := os.MkdirAll(path.Join(sourceDir, "b"), 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(targetDir, 0777); err != nil {
+	if err := os.Mkdir(targetDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(outside1Dir, 0777); err != nil {
+	if err := os.Mkdir(outside1Dir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(outside2Dir, 0777); err != nil {
+	if err := os.Mkdir(outside2Dir, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -119,7 +119,7 @@ func TestSubtreeShared(t *testing.T) {
 	}
 
 	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0777); err != nil {
+	if err := os.MkdirAll(tmp, 0o777); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
@@ -133,13 +133,13 @@ func TestSubtreeShared(t *testing.T) {
 		sourceCheckPath = path.Join(sourceDir, "a", "file.txt")
 	)
 
-	if err := os.MkdirAll(path.Join(sourceDir, "a"), 0777); err != nil {
+	if err := os.MkdirAll(path.Join(sourceDir, "a"), 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(targetDir, 0777); err != nil {
+	if err := os.Mkdir(targetDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(outsideDir, 0777); err != nil {
+	if err := os.Mkdir(outsideDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -191,7 +191,7 @@ func TestSubtreeSharedSlave(t *testing.T) {
 	}
 
 	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0777); err != nil {
+	if err := os.MkdirAll(tmp, 0o777); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
@@ -207,19 +207,19 @@ func TestSubtreeSharedSlave(t *testing.T) {
 		outside1CheckPath = path.Join(targetDir, "a", "file.txt")
 		outside2CheckPath = path.Join(sourceDir, "b", "file.txt")
 	)
-	if err := os.MkdirAll(path.Join(sourceDir, "a"), 0777); err != nil {
+	if err := os.MkdirAll(path.Join(sourceDir, "a"), 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(path.Join(sourceDir, "b"), 0777); err != nil {
+	if err := os.MkdirAll(path.Join(sourceDir, "b"), 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(targetDir, 0777); err != nil {
+	if err := os.Mkdir(targetDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(outside1Dir, 0777); err != nil {
+	if err := os.Mkdir(outside1Dir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(outside2Dir, 0777); err != nil {
+	if err := os.Mkdir(outside2Dir, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -299,7 +299,7 @@ func TestSubtreeUnbindable(t *testing.T) {
 	}
 
 	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0777); err != nil {
+	if err := os.MkdirAll(tmp, 0o777); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
@@ -308,10 +308,10 @@ func TestSubtreeUnbindable(t *testing.T) {
 		sourceDir = path.Join(tmp, "source")
 		targetDir = path.Join(tmp, "target")
 	)
-	if err := os.MkdirAll(sourceDir, 0777); err != nil {
+	if err := os.MkdirAll(sourceDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(targetDir, 0777); err != nil {
+	if err := os.MkdirAll(targetDir, 0o777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -339,5 +339,5 @@ func TestSubtreeUnbindable(t *testing.T) {
 }
 
 func createFile(path string) error {
-	return ioutil.WriteFile(path, []byte("hello"), 0666)
+	return ioutil.WriteFile(path, []byte("hello"), 0o666)
 }

--- a/mount/sharedsubtree_linux_test.go
+++ b/mount/sharedsubtree_linux_test.go
@@ -326,7 +326,7 @@ func TestSubtreeUnbindable(t *testing.T) {
 	}()
 
 	// then attempt to mount it to target. It should fail
-	if err := Mount(sourceDir, targetDir, "none", "bind,rw"); err != nil && errors.Unwrap(err) != unix.EINVAL {
+	if err := Mount(sourceDir, targetDir, "none", "bind,rw"); err != nil && !errors.Is(err, unix.EINVAL) {
 		t.Fatal(err)
 	} else if err == nil {
 		t.Fatalf("%q should not have been bindable", sourceDir)

--- a/mountinfo/mounted_linux.go
+++ b/mountinfo/mounted_linux.go
@@ -23,7 +23,7 @@ func mountedByOpenat2(path string) (bool, error) {
 		Resolve: unix.RESOLVE_NO_XDEV,
 	})
 	_ = unix.Close(dirfd)
-	switch err {
+	switch err { //nolint:errorlint // unix errors are bare
 	case nil: // definitely not a mount
 		_ = unix.Close(fd)
 		return false, nil

--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -770,5 +770,4 @@ func TestUnescape(t *testing.T) {
 			continue
 		}
 	}
-
 }

--- a/symlink/fs_unix_test.go
+++ b/symlink/fs_unix_test.go
@@ -24,10 +24,10 @@ func makeFs(tmpdir string, fs []dirOrLink) error {
 	for _, s := range fs {
 		s.path = filepath.Join(tmpdir, s.path)
 		if s.target == "" {
-			_ = os.MkdirAll(s.path, 0755)
+			_ = os.MkdirAll(s.path, 0o755)
 			continue
 		}
-		if err := os.MkdirAll(filepath.Dir(s.path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
 			return err
 		}
 		if err := os.Symlink(s.target, s.path); err != nil && !os.IsExist(err) {

--- a/symlink/fs_windows.go
+++ b/symlink/fs_windows.go
@@ -101,7 +101,7 @@ func walkSymlinks(path string) (string, error) {
 		}
 
 		// find next path component, p
-		var i = -1
+		i := -1
 		for j, c := range path {
 			if c < utf8RuneSelf && os.IsPathSeparator(uint8(c)) {
 				i = j


### PR DESCRIPTION
~~_(currently a draft pending #90 merge)_~~

* Enable some linters, fix their warnings.
* Update golangci-lint to 1.43.0.
* Force LF line endings for .go files.

Fixes: #91