### PR TITLE
mountinfo: introduce MountedBind

### DIFF
--- a/mountinfo/mounted_linux.go
+++ b/mountinfo/mounted_linux.go
@@ -7,6 +7,82 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// MountedBind is a Linux-specific function, similar to Mounted, but with
+// additional workarounds to decrease the possibility of misdetecting
+// a bind mount.
+//
+// On Linux (before kernel 5.8) bind mount detection is not reliable (false
+// negatives are possible) on systems that perform lots of mounts and unmounts,
+// due to a kernel issue. This function tries to mitigate that issue by
+// re-reading mountinfo, decreasing the possibility of a false negative.
+//
+// This function increases system load. It should only be used for bind
+// mounts, if a user wants to sacrifice system performance for higher reliability.
+func MountedBind(path string) (bool, error) {
+	return mountedWithFallback(path, mountedByMountinfoWithRetries)
+}
+
+// mountedByMountinfoWithRetries is like mountedByMountinfo, with
+// the addition of a workaround for a kernel bug (fixed in Linux 5.8).
+// This kernel bug is essentially a race between reading mountinfo
+// and performing an unmount. In the case next to be read mount entry is
+// removed from the kernel data structures, it prematurely returns EOF.
+// As a result, sometimes only a half of mountinfo is read, leading to
+// inability to find a legitimate existing mount.
+//
+// Alas, there is no good solution to that problem. A workaround, implemented
+// here, is to re-read mountinfo again if the mount is not found. With multiple
+// re-reads, the chances of repeatedly hitting the race are decreasing.
+//
+// Those re-reads are costly, so there is an additional optimization -- we
+// assume that if two subsequent reads returned the same number of entries,
+// there is no issue, and thus there is no need to re-read mountinfo again.
+// This is not a great heuristic but in case there are no parallel
+// mounts/unmounts it limits the number of reads to 2.
+//
+// Note that the main idea here is not to get two consecutive consistent
+// readings (with the same number of entries), but rather a complete reading.
+// Since there is no way to figure out if the reading is complete, we compare
+// the number of entries between the two readings.
+//
+// Finally, in case of massively parallel mounts/unmounts the number of entries
+// will always be different, and in this case maxTries is the main mechanism to
+// exit the re-reading loop.
+func mountedByMountinfoWithRetries(path string) (bool, error) {
+	var total, oldTotal, try int
+	const maxTries = 3
+
+again:
+	// The filter is the same as SingleEntryFilter,
+	// with the addition of counting total entries.
+	entries, err := GetMounts(func(m *Info) (bool, bool) {
+		if m.Mountpoint == path {
+			return false, true // don't skip, stop now
+		}
+		total++
+		return true, false // skip, keep going
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(entries) > 0 {
+		return true, nil
+	}
+
+	try++
+	if try == maxTries {
+		return false, nil
+	} else if total == oldTotal {
+		// Two last reads resulted in the same number of entries,
+		// which most probably means we get a complete reading.
+		return false, nil
+	} else {
+		oldTotal = total
+		total = 0
+		goto again
+	}
+}
+
 // mountedByOpenat2 is a method of detecting a mount that works for all kinds
 // of mounts (incl. bind mounts), but requires a recent (v5.6+) linux kernel.
 func mountedByOpenat2(path string) (bool, error) {
@@ -34,7 +110,9 @@ func mountedByOpenat2(path string) (bool, error) {
 	return false, &os.PathError{Op: "openat2", Path: path, Err: err}
 }
 
-func mounted(path string) (bool, error) {
+// mountedWithFallback tries all the fast approaches to figure out whether path
+// is a mount point. It calls fallbackFn if all those approarches failed.
+func mountedWithFallback(path string, fallbackFn func(string) (bool, error)) (bool, error) {
 	path, err := normalizePath(path)
 	if err != nil {
 		return false, err
@@ -53,5 +131,9 @@ func mounted(path string) (bool, error) {
 	}
 
 	// Fallback to parsing mountinfo
-	return mountedByMountinfo(path)
+	return fallbackFn(path)
+}
+
+func mounted(path string) (bool, error) {
+	return mountedWithFallback(path, mountedByMountinfo)
 }

--- a/mountinfo/mounted_linux_test.go
+++ b/mountinfo/mounted_linux_test.go
@@ -282,7 +282,7 @@ func TestMountedBy(t *testing.T) {
 	checked := false
 
 	// List of individual implementations to check.
-	toCheck := []func(string) (bool, error){mountedByMountinfo, mountedByStat}
+	toCheck := []func(string) (bool, error){mountedByMountinfo, mountedByMountinfoWithRetries, mountedByStat}
 	if tryOpenat2() == nil {
 		toCheck = append(toCheck, mountedByOpenat2)
 	}

--- a/mountinfo/mountinfo.go
+++ b/mountinfo/mountinfo.go
@@ -16,6 +16,11 @@ func GetMounts(f FilterFunc) ([]*Info, error) {
 // The non-existent path returns an error. If a caller is not interested
 // in this particular error, it should handle it separately using e.g.
 // errors.Is(err, os.ErrNotExist).
+//
+// Note that on Linux (before kernel 5.8) bind mount detection is not reliable
+// (false negatives are possible) on systems that perform lots of mounts and
+// unmounts. For an implementation with lower probability of false negatives
+// with bind mounts, see MountedBind.
 func Mounted(path string) (bool, error) {
 	// root is always mounted
 	if path == string(os.PathSeparator) {


### PR DESCRIPTION
`MountedBind` is a Linux-specific function, similar to Mounted, but with
additional workarounds to decrease the possibility of misdetecting
a bind mount.

On Linux (before kernel 5.8, which includes [commit 9f6c61f96f2d97](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9f6c61f96f2d97cbb5f7fa85607bc398f843ff0f), and when
`openat2()` syscall (appeared in kernel 5.6) is not available) bind mount detection
is not reliable (false negatives are possible) on systems that perform
lots of mounts and unmounts, due to a kernel issue.

This function tries to mitigate that issue by re-reading mountinfo, thus
decreasing the possibility of a false negative.

This function increases system load. It should only be used for bind
mounts, if a user wants to sacrifice system performance for higher reliability
to detect a bind mount.