### PR TITLE
Expose MountedByOpenat2 as a public function so that k8s can consume

### DIFF
--- a/mountinfo/mounted_linux.go
+++ b/mountinfo/mounted_linux.go
@@ -7,9 +7,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// mountedByOpenat2 is a method of detecting a mount that works for all kinds
+// MountedByOpenat2 is a method of detecting a mount that works for all kinds
 // of mounts (incl. bind mounts), but requires a recent (v5.6+) linux kernel.
-func mountedByOpenat2(path string) (bool, error) {
+func MountedByOpenat2(path string) (bool, error) {
 	dir, last := filepath.Split(path)
 
 	dirfd, err := unix.Openat2(unix.AT_FDCWD, dir, &unix.OpenHow{
@@ -40,7 +40,7 @@ func mounted(path string) (bool, error) {
 		return false, err
 	}
 	// Try a fast path, using openat2() with RESOLVE_NO_XDEV.
-	mounted, err := mountedByOpenat2(path)
+	mounted, err := MountedByOpenat2(path)
 	if err == nil {
 		return mounted, nil
 	}

--- a/mountinfo/mounted_linux_test.go
+++ b/mountinfo/mounted_linux_test.go
@@ -342,15 +342,15 @@ func TestMountedBy(t *testing.T) {
 			if !openat2Supported {
 				return
 			}
-			mounted, err = mountedByOpenat2(m)
+			mounted, err = MountedByOpenat2(m)
 			if err != nil {
-				t.Errorf("mountedByOpenat2 error: %v", err)
+				t.Errorf("MountedByOpenat2 error: %v", err)
 				// Check false is returned in error case.
 				if mounted != false {
 					t.Errorf("MountedByOpenat2: expected false on error, got %v", mounted)
 				}
 			} else if mounted != exp {
-				t.Errorf("mountedByOpenat2: expected %v, got %v", exp, mounted)
+				t.Errorf("MountedByOpenat2: expected %v, got %v", exp, mounted)
 			}
 		})
 
@@ -375,13 +375,13 @@ func TestMountedByOpenat2VsMountinfo(t *testing.T) {
 			// (this special case is handled by Mounted).
 			continue
 		}
-		mounted, err := mountedByOpenat2(m)
+		mounted, err := MountedByOpenat2(m)
 		if err != nil {
 			if !errors.Is(err, os.ErrPermission) {
-				t.Errorf("mountedByOpenat2(%q) error: %+v", m, err)
+				t.Errorf("MountedByOpenat2(%q) error: %+v", m, err)
 			}
 		} else if !mounted {
-			t.Errorf("mountedByOpenat2(%q): expected true, got false", m)
+			t.Errorf("MountedByOpenat2(%q): expected true, got false", m)
 		}
 	}
 }


### PR DESCRIPTION
Expose MountedByOpenat2 as a public function so that k8s can consume

One of the alternatives suggested here is to expose MountedByOpenat2 as a public function
so that k8s can consume and rest of the downstream can also benefit from it.

https://github.com/kubernetes/kubernetes/pull/105833#issuecomment-985591009

cc @kolyshkin 