### PR TITLE
Introduce MountedFast function to determine mount points faster.

### DIFF
--- a/mountinfo/mounted_linux.go
+++ b/mountinfo/mounted_linux.go
@@ -7,6 +7,50 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// MountedFast is a method of detecting mount points without reading
+// mountinfo from procfs. A mount point check is guaranteed to be a
+// mount point or not only when sure is true. When sure is false, the
+// caller needs to check for other methods (eg: parse /proc/mounts)
+// to successfully determine if it is a mount point. This function
+// is only available on Linux.
+func MountedFast(path string) (mounted, sure bool, err error) {
+	// root is always mounted
+	if path == string(os.PathSeparator) {
+		return true, true, nil
+	}
+
+	path, err = normalizePath(path)
+	if err != nil {
+		return false, false, err
+	}
+
+	return mountedFast(path)
+}
+
+// mountedFast combines mountedByOpenAt2 and mountedByStat.
+// A mount point check is guaranteed to be a mount point or not only
+// when sure is true. When sure is false, the caller needs to check
+// for other methods (eg: parse /proc/mounts) to successfully
+// determine if it is a mount point.
+func mountedFast(normalizedPath string) (mounted, sure bool, err error) {
+	// Try a fast path, using openat2() with RESOLVE_NO_XDEV.
+	mounted, err = mountedByOpenat2(normalizedPath)
+	if err == nil {
+		return mounted, true, nil
+	}
+
+	// Another fast path: compare st.st_dev fields.
+	mounted, err = mountedByStat(normalizedPath)
+	// This does not work for bind mounts, so false negative
+	// is possible, therefore only trust if return is true.
+	if mounted && err == nil {
+		return mounted, true, nil
+	}
+
+	// NB: not sure
+	return false, false, err
+}
+
 // mountedByOpenat2 is a method of detecting a mount that works for all kinds
 // of mounts (incl. bind mounts), but requires a recent (v5.6+) linux kernel.
 func mountedByOpenat2(path string) (bool, error) {
@@ -39,16 +83,10 @@ func mounted(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	// Try a fast path, using openat2() with RESOLVE_NO_XDEV.
-	mounted, err := mountedByOpenat2(path)
-	if err == nil {
-		return mounted, nil
-	}
-	// Another fast path: compare st.st_dev fields.
-	mounted, err = mountedByStat(path)
-	// This does not work for bind mounts, so false negative
-	// is possible, therefore only trust if return is true.
-	if mounted && err == nil {
+
+	// Try all fast paths.
+	mounted, sure, err := mountedFast(path)
+	if sure && err == nil {
 		return mounted, nil
 	}
 


### PR DESCRIPTION
MountedFast is a method of detecting mount points really fast.
It works for all kinds of mounts (incl. bind mounts) but requires
a recent (v5.6+) Linux kernel. A mount-point check is guaranteed to
be a mount-point or not only when sure is true. When sure is false,
the caller needs to check for other methods (eg: parse /proc/mounts)
to successfully determine if it is a mount-point.

This has been motivated by
https://github.com/kubernetes/kubernetes/pull/105833#issuecomment-985591009
and
https://github.com/moby/sys/pull/96#issuecomment-985952881


## Context
The context is that; k8s relies on reading /proc/mounts to determine mount points. It also enforces a consistency check (ie ensure that two reads of proc/mounts are exactly the same) before determining a mount-point which leads to resource contention. This is different than docker where a lock is acquired before reading the entire /proc/mounts.

Now, k8s wont remove the consistency check as it could lead to all sorts of error that Kir demonstrated here (https://github.com/kolyshkin/procfs-test) and the consistency check mitigates that.

To solve for that k8s took inspiration from moby/sys to do its own openat2 call (https://github.com/kubernetes/kubernetes/pull/105833) and when openat2 is not available, fallback on reading /proc/mounts with the consistency check I mentioned above.

During the course of the discussion, Kir suggested it might be better to upstream the change to moby/sys and k8s can take it as a dependency which is what this PR does. It introduces a MountedFast  which uses openat2 (for kernel 5.6+) or stat calls to determine a mount-point, it sends back a sure bool to the caller to guarantee the caller if it is a mount-point or not.
k8s will now first call MountedFast when this change is merged and then if sure is false or an error is thrown, it will fall back to reading /proc/mounts. This is beneficial for k8s on newer kernels as they will never read /proc/mounts because of openat2 path and for older kernels only bind mounts will be validated using /proc/mounts.