### PR TITLE
mount: fix unused/deadcode warnings on Mac

### DIFF
--- a/mount/mount_errors.go
+++ b/mount/mount_errors.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !darwin && !windows
+// +build !darwin,!windows
 
 package mount
 

--- a/mount/mounter_unsupported.go
+++ b/mount/mounter_unsupported.go
@@ -1,5 +1,5 @@
-//go:build (!linux && !freebsd && !openbsd && !windows) || (freebsd && !cgo) || (openbsd && !cgo)
-// +build !linux,!freebsd,!openbsd,!windows freebsd,!cgo openbsd,!cgo
+//go:build (!linux && !freebsd && !openbsd && !windows && !darwin) || (freebsd && !cgo) || (openbsd && !cgo)
+// +build !linux,!freebsd,!openbsd,!windows,!darwin freebsd,!cgo openbsd,!cgo
 
 package mount
 


### PR DESCRIPTION
Since commit 7a521626bc899dc Mount is not implemented on Darwin, so
mount() is left unused.

Also, mount errors are only used from mount(), and thus are not used on
Darwin.

This fixes a bunch of warnings from "unused" and "deadcode" lints.

Alas, those warnings did not result in CI failures on Mac; see https://github.com/moby/sys/issues/99