### PR TITLE
Makefile: rm .SHELLFLAGS, add set -e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-.SHELLFLAGS = -ec
 PACKAGES ?= mountinfo mount signal symlink
 BINDIR ?= _build/bin
 CROSS ?= linux/arm linux/arm64 linux/ppc64le linux/s390x \
@@ -15,8 +14,9 @@ clean:
 
 .PHONY: test
 test: test-local
+	set -eu; \
 	for p in $(PACKAGES); do \
-		(cd $$p && go test $(RUN_VIA_SUDO) -v .); \
+		(cd $$p; go test $(RUN_VIA_SUDO) -v .); \
 	done
 
 # Test the mount module against the local mountinfo source code instead of the
@@ -33,9 +33,11 @@ test-local:
 .PHONY: lint
 lint: $(BINDIR)/golangci-lint
 	$(BINDIR)/golangci-lint version
+	set -eu; \
 	for p in $(PACKAGES); do \
-		(cd $$p && go mod download \
-		&& ../$(BINDIR)/golangci-lint run); \
+		(cd $$p; \
+		go mod download; \
+		../$(BINDIR)/golangci-lint run); \
 	done
 
 $(BINDIR)/golangci-lint: $(BINDIR)
@@ -46,10 +48,11 @@ $(BINDIR):
 
 .PHONY: cross
 cross:
+	set -eu; \
 	for osarch in $(CROSS); do \
 		export GOOS=$${osarch%/*} GOARCH=$${osarch#*/}; \
 		echo "# building for $$GOOS/$$GOARCH"; \
 		for p in $(PACKAGES); do \
-			(cd $$p	&& go build .); \
+			(cd $$p; go build .); \
 		done; \
 	done


### PR DESCRIPTION
Apparently GHA CI Mac OS X environment uses old GNU Make (v3.81) which
does not yet support `.SHELLFLAGS` (added by commit 8589e2e7).

Since we call a few commands (under `for`) from the make target,
intermediate failures are ignored unless `-e` shell option is set (or
explicit `&&` is used, which is not possible to do in `for`).

Example:

```sh
for cmd in false true; do $cmd; done
```
will succeed unless `set -e` is set, because the last command executed is `true` and its exit code is `0`.

To fix, use explicit `set -e` where we execute more than a single command.

Also, replace `&&` with `;` for multiple commands. Technically this is not
required for the fix, but since having `set -e` results in implicit `&&` everywhere,
there is no need to have `&&` explicitly. In other words, this change is
more like a reminder that we do not have to use `&&` here.

Fixes: 8589e2e7

Fixes: #99