### PR TITLE
mount: trivial test nitpicks

### DIFF
--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -34,13 +34,8 @@ func TestMounted(t *testing.T) {
 		t.Skip("root required")
 	}
 
-	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0o777); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
-
 	var (
+		tmp        = t.TempDir()
 		sourceDir  = path.Join(tmp, "source")
 		targetDir  = path.Join(tmp, "target")
 		sourcePath = path.Join(sourceDir, "file.txt")
@@ -104,12 +99,7 @@ func TestMountTmpfsOptions(t *testing.T) {
 		},
 	}
 
-	target := path.Join(os.TempDir(), "mount-tmpfs-tests-"+t.Name())
-	if err := os.MkdirAll(target, 0o777); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(target)
-
+	target := t.TempDir()
 	for _, tc := range testCases {
 		t.Run(tc.opts, func(t *testing.T) {
 			if err := Mount("tmpfs", target, "tmpfs", tc.opts); err != nil {
@@ -141,13 +131,8 @@ func TestMountReadonly(t *testing.T) {
 		t.Skip("root required")
 	}
 
-	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0o777); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
-
 	var (
+		tmp        = t.TempDir()
 		sourceDir  = path.Join(tmp, "source")
 		targetDir  = path.Join(tmp, "target")
 		sourcePath = path.Join(sourceDir, "file.txt")
@@ -211,12 +196,7 @@ func TestRecursiveUnmountTooGreedy(t *testing.T) {
 		t.Skip("root required")
 	}
 
-	tmp, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
-
+	tmp := t.TempDir()
 	// Create a bunch of tmpfs mounts. Make sure "dir" itself is not
 	// a mount point, or we'll hit the fast path in RecursiveUnmount.
 	dirs := []string{"dir-other", "dir/subdir1", "dir/subdir1/subsub", "dir/subdir2/subsub"}

--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -4,7 +4,6 @@
 package mount
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -49,11 +48,11 @@ func TestMounted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(sourcePath, []byte("hello"), 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(targetPath, nil, 0o644); err != nil {
+	if err := os.WriteFile(targetPath, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,11 +145,11 @@ func TestMountReadonly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(sourcePath, []byte("hello"), 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(targetPath, nil, 0o644); err != nil {
+	if err := os.WriteFile(targetPath, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -163,7 +162,7 @@ func TestMountReadonly(t *testing.T) {
 		}
 	}()
 
-	if err := ioutil.WriteFile(targetPath, []byte("hello"), 0o644); err == nil {
+	if err := os.WriteFile(targetPath, []byte("hello"), 0o644); err == nil {
 		t.Fatal("Should not be able to open a ro file as rw")
 	}
 }

--- a/mount/mounter_linux_test.go
+++ b/mount/mounter_linux_test.go
@@ -2,7 +2,6 @@ package mount
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -15,12 +14,7 @@ func TestMount(t *testing.T) {
 		t.Skip("root required")
 	}
 
-	source, err := ioutil.TempDir("", "mount-test-source-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(source)
-
+	source := t.TempDir()
 	// Ensure we have a known start point by mounting tmpfs with given options
 	if err := Mount("tmpfs", source, "tmpfs", "private"); err != nil {
 		t.Fatal(err)
@@ -31,11 +25,7 @@ func TestMount(t *testing.T) {
 		t.FailNow()
 	}
 
-	target, err := ioutil.TempDir("", "mount-test-target-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(target)
+	target := t.TempDir()
 
 	tests := []struct {
 		source           string

--- a/mount/sharedsubtree_linux_test.go
+++ b/mount/sharedsubtree_linux_test.go
@@ -44,10 +44,10 @@ func TestSubtreePrivate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := createFile(outside1Path); err != nil {
+	if err := os.WriteFile(outside1Path, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := createFile(outside2Path); err != nil {
+	if err := os.WriteFile(outside2Path, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -134,7 +134,7 @@ func TestSubtreeShared(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := createFile(outsidePath); err != nil {
+	if err := os.WriteFile(outsidePath, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -210,10 +210,10 @@ func TestSubtreeSharedSlave(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := createFile(outside1Path); err != nil {
+	if err := os.WriteFile(outside1Path, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := createFile(outside2Path); err != nil {
+	if err := os.WriteFile(outside2Path, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -318,8 +318,4 @@ func TestSubtreeUnbindable(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-}
-
-func createFile(path string) error {
-	return os.WriteFile(path, []byte("hello"), 0o666)
 }

--- a/mount/sharedsubtree_linux_test.go
+++ b/mount/sharedsubtree_linux_test.go
@@ -2,7 +2,6 @@ package mount
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -322,5 +321,5 @@ func TestSubtreeUnbindable(t *testing.T) {
 }
 
 func createFile(path string) error {
-	return ioutil.WriteFile(path, []byte("hello"), 0o666)
+	return os.WriteFile(path, []byte("hello"), 0o666)
 }

--- a/mount/sharedsubtree_linux_test.go
+++ b/mount/sharedsubtree_linux_test.go
@@ -16,13 +16,9 @@ func TestSubtreePrivate(t *testing.T) {
 		t.Skip("root required")
 	}
 
-	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0o777); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
-
 	var (
+		tmp = t.TempDir()
+
 		sourceDir   = path.Join(tmp, "source")
 		targetDir   = path.Join(tmp, "target")
 		outside1Dir = path.Join(tmp, "outside1")
@@ -118,13 +114,9 @@ func TestSubtreeShared(t *testing.T) {
 		t.Skip("root required")
 	}
 
-	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0o777); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
-
 	var (
+		tmp = t.TempDir()
+
 		sourceDir  = path.Join(tmp, "source")
 		targetDir  = path.Join(tmp, "target")
 		outsideDir = path.Join(tmp, "outside")
@@ -190,13 +182,9 @@ func TestSubtreeSharedSlave(t *testing.T) {
 		t.Skip("root required")
 	}
 
-	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0o777); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
-
 	var (
+		tmp = t.TempDir()
+
 		sourceDir   = path.Join(tmp, "source")
 		targetDir   = path.Join(tmp, "target")
 		outside1Dir = path.Join(tmp, "outside1")
@@ -298,13 +286,8 @@ func TestSubtreeUnbindable(t *testing.T) {
 		t.Skip("root required")
 	}
 
-	tmp := path.Join(os.TempDir(), "mount-tests")
-	if err := os.MkdirAll(tmp, 0o777); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
-
 	var (
+		tmp       = t.TempDir()
 		sourceDir = path.Join(tmp, "source")
 		targetDir = path.Join(tmp, "target")
 	)


### PR DESCRIPTION
- use `t.TempDir`
- use `os.WriteFile` instead of `ioutil.WriteFile`
- remove `createFile`