### PR TITLE
Do not wrap errors from filepath / os as they are already wrapped.

### DIFF
--- a/mountinfo/mounted_unix.go
+++ b/mountinfo/mounted_unix.go
@@ -4,7 +4,6 @@
 package mountinfo
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -33,13 +32,13 @@ func mountedByStat(path string) (bool, error) {
 
 func normalizePath(path string) (realPath string, err error) {
 	if realPath, err = filepath.Abs(path); err != nil {
-		return "", fmt.Errorf("unable to get absolute path for %q: %w", path, err)
+		return "", err
 	}
 	if realPath, err = filepath.EvalSymlinks(realPath); err != nil {
-		return "", fmt.Errorf("failed to canonicalise path for %q: %w", path, err)
+		return "", err
 	}
 	if _, err := os.Stat(realPath); err != nil {
-		return "", fmt.Errorf("failed to stat target of %q: %w", path, err)
+		return "", err
 	}
 	return realPath, nil
 }


### PR DESCRIPTION
While trying to import MountedFast into k8s to detect mount points
using openat2, several tests failed because they rely on
os.IsErrNotExist / os.IsPermission which do not actually test the
underlying error.

For a non-existent path, if we return the bare error, this problem
is solved. I tested for the following cases to ensure that
backward compatibility is not broken:

````
fmt.Println(os.IsNotExist(err)) returns false
fmt.Println(os.IsNotExist(&os.PathError{
		Op:   "lstat",
		Path: "somepath",
		Err:  err,
})) returns false

fmt.Println(os.IsNotExist(fmt.Errorf("unable: %w", err))) returns false
fmt.Println(errors.Is(fmt.Errorf("unable: %w", err), os.ErrNotExist))
returns true.
```

cc @kolyshkin @thaJeztah 