### PR TITLE
mountinfo: BSDs no longer need cgo

### DIFF
--- a/mountinfo/mounted_unix.go
+++ b/mountinfo/mounted_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || (freebsd && cgo) || (openbsd && cgo) || (darwin && cgo)
-// +build linux freebsd,cgo openbsd,cgo darwin,cgo
+//go:build linux || freebsd || openbsd || darwin
+// +build linux freebsd openbsd darwin
 
 package mountinfo
 

--- a/mountinfo/mountinfo_bsd.go
+++ b/mountinfo/mountinfo_bsd.go
@@ -32,7 +32,7 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 		return nil, err
 	}
 
-	var entries = make([]syscall.Statfs_t, count)
+	entries := make([]syscall.Statfs_t, count)
 	_, err = syscall.Getfsstat(entries, 1 /* MNT_WAIT */)
 	if err != nil {
 		return nil, err

--- a/mountinfo/mountinfo_unsupported.go
+++ b/mountinfo/mountinfo_unsupported.go
@@ -1,5 +1,5 @@
-//go:build (!windows && !linux && !freebsd && !openbsd && !darwin) || (freebsd && !cgo) || (openbsd && !cgo) || (darwin && !cgo)
-// +build !windows,!linux,!freebsd,!openbsd,!darwin freebsd,!cgo openbsd,!cgo darwin,!cgo
+//go:build !windows && !linux && !freebsd && !openbsd && !darwin
+// +build !windows,!linux,!freebsd,!openbsd,!darwin
 
 package mountinfo
 


### PR DESCRIPTION
This fix https://github.com/containerd/nerdctl/issues/868