### PR TITLE
Update doc to use fs.ErrNotExist

### DIFF
--- a/mountinfo/mounted_linux.go
+++ b/mountinfo/mounted_linux.go
@@ -15,7 +15,7 @@ import (
 //
 // If a non-existent path is specified, an appropriate error is returned.
 // In case the caller is not interested in this particular error, it should
-// be handled separately using e.g. errors.Is(err, os.ErrNotExist).
+// be handled separately using e.g. errors.Is(err, fs.ErrNotExist).
 //
 // This function is only available on Linux. When available (since kernel
 // v5.6), openat2(2) syscall is used to reliably detect all mounts. Otherwise,

--- a/mountinfo/mountinfo.go
+++ b/mountinfo/mountinfo.go
@@ -15,7 +15,7 @@ func GetMounts(f FilterFunc) ([]*Info, error) {
 //
 // If a non-existent path is specified, an appropriate error is returned.
 // In case the caller is not interested in this particular error, it should
-// be handled separately using e.g. errors.Is(err, os.ErrNotExist).
+// be handled separately using e.g. errors.Is(err, fs.ErrNotExist).
 func Mounted(path string) (bool, error) {
 	// root is always mounted
 	if path == string(os.PathSeparator) {


### PR DESCRIPTION
There are two nits:
1. Since go 1.18, the doc recommends errors.Is(err, fs.ErrNotExist) rather than errors.Is(err, os.ErrNotExist); hence the doc update.