### PR TITLE
update golang.org/x/sys v0.0.0-20220412211240-33da011f77ad

### DIFF
--- a/mount/go.mod
+++ b/mount/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/moby/sys/mountinfo v0.6.1
-	golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
 )

--- a/mount/go.sum
+++ b/mount/go.sum
@@ -1,4 +1,5 @@
 github.com/moby/sys/mountinfo v0.6.1 h1:+H/KnGEAGRpTrEAqNVQ2AM3SiwMgJUt/TXj+Z8cmCIc=
 github.com/moby/sys/mountinfo v0.6.1/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/mountinfo/go.mod
+++ b/mountinfo/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/mountinfo
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359
+require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad

--- a/mountinfo/go.sum
+++ b/mountinfo/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/signal
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359
+require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad

--- a/signal/go.sum
+++ b/signal/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/symlink/go.mod
+++ b/symlink/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/symlink
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359
+require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad

--- a/symlink/go.sum
+++ b/symlink/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Includes fixes for:

- CVE-2022-29526 (http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29526);
  (description at https://go.dev/issue/52313).

full diff: https://github.com/golang/sys/compare/69cdffdb9359ff97d91e4f4fbb6b2714c3898eae...33da011f77ade50ff5b6a6fb4a9a1e6d6b285809
