### PR TITLE
Bump x/sys/unix

### DIFF
--- a/mount/go.mod
+++ b/mount/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/moby/sys/mountinfo v0.6.1
-	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 )

--- a/mount/go.sum
+++ b/mount/go.sum
@@ -1,5 +1,5 @@
 github.com/moby/sys/mountinfo v0.6.1 h1:+H/KnGEAGRpTrEAqNVQ2AM3SiwMgJUt/TXj+Z8cmCIc=
 github.com/moby/sys/mountinfo v0.6.1/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/mountinfo/go.mod
+++ b/mountinfo/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/mountinfo
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a

--- a/mountinfo/go.sum
+++ b/mountinfo/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/mountinfo/mountinfo_freebsdlike.go
+++ b/mountinfo/mountinfo_freebsdlike.go
@@ -6,9 +6,9 @@ package mountinfo
 import "golang.org/x/sys/unix"
 
 func getMountinfo(entry *unix.Statfs_t) *Info {
-	var mountinfo Info
-	mountinfo.Mountpoint = unix.ByteSliceToString(entry.Mntonname[:])
-	mountinfo.FSType = unix.ByteSliceToString(entry.Fstypename[:])
-	mountinfo.Source = unix.ByteSliceToString(entry.Mntfromname[:])
-	return &mountinfo
+	return &Info{
+		Mountpoint: unix.ByteSliceToString(entry.Mntonname[:]),
+		FSType:     unix.ByteSliceToString(entry.Fstypename[:]),
+		Source:     unix.ByteSliceToString(entry.Mntfromname[:]),
+	}
 }

--- a/mountinfo/mountinfo_openbsd.go
+++ b/mountinfo/mountinfo_openbsd.go
@@ -2,21 +2,10 @@ package mountinfo
 
 import "golang.org/x/sys/unix"
 
-func int8SliceToString(is []int8) string {
-	var bs []byte
-	for _, i := range is {
-		if i == 0 {
-			break
-		}
-		bs = append(bs, byte(i))
-	}
-	return string(bs)
-}
-
 func getMountinfo(entry *unix.Statfs_t) *Info {
-	var mountinfo Info
-	mountinfo.Mountpoint = int8SliceToString(entry.F_mntonname[:])
-	mountinfo.FSType = int8SliceToString(entry.F_fstypename[:])
-	mountinfo.Source = int8SliceToString(entry.F_mntfromname[:])
-	return &mountinfo
+	return &Info{
+		Mountpoint: unix.ByteSliceToString(entry.F_mntonname[:]),
+		FSType:     unix.ByteSliceToString(entry.F_fstypename[:]),
+		Source:     unix.ByteSliceToString(entry.F_mntfromname[:]),
+	}
 }

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/signal
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a

--- a/signal/go.sum
+++ b/signal/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/symlink/go.mod
+++ b/symlink/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/symlink
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a

--- a/symlink/go.sum
+++ b/symlink/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
A newer version of x/sys/unix updates the OpenBSD bindings
which makes the `int8SliceToString` helper function obsolete.

This change updates the x/sys/unix version