### PR TITLE
ci: add go mod tidy check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v3
+    - name: go mod tidy
+      run: |
+        make tidy
+        git diff --exit-code
     - name: Lint
       run: make lint
     - name: Cross build

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@ test: test-local
 		(cd $$p; go test $(RUN_VIA_SUDO) -v .); \
 	done
 
+.PHONY: tidy
+tidy:
+	set -eu; \
+		for p in $(PACKAGES); do \
+		(cd $$p; go mod tidy); \
+	done
+
 # Test the mount module against the local mountinfo source code instead of the
 # release specified in its go.mod. This allows catching regressions / breaking
 # changes in mountinfo.


### PR DESCRIPTION
This step should fail if a PR author bumped or added some dependencies,
or bumped go version in `go.mod`, but forgot to run `go mod tidy`.

Inspired by https://github.com/moby/sys/pull/118#discussion_r890371395