### PR TITLE
sequential: refactor, and update godoc

### DIFF
--- a/sequential/sequential_unix.go
+++ b/sequential/sequential_unix.go
@@ -5,41 +5,22 @@ package sequential
 
 import "os"
 
-// Create creates the named file with mode 0666 (before umask), truncating
-// it if it already exists. If successful, methods on the returned
-// File can be used for I/O; the associated file descriptor has mode
-// O_RDWR.
-// If there is an error, it will be of type *PathError.
+// Create is an alias for [os.Create] on non-Windows platforms.
 func Create(name string) (*os.File, error) {
 	return os.Create(name)
 }
 
-// Open opens the named file for reading. If successful, methods on
-// the returned file can be used for reading; the associated file
-// descriptor has mode O_RDONLY.
-// If there is an error, it will be of type *PathError.
+// Open is an alias for [os.Open] on non-Windows platforms.
 func Open(name string) (*os.File, error) {
 	return os.Open(name)
 }
 
-// OpenFile is the generalized open call; most users will use Open
-// or Create instead. It opens the named file with specified flag
-// (O_RDONLY etc.) and perm, (0666 etc.) if applicable. If successful,
-// methods on the returned File can be used for I/O.
-// If there is an error, it will be of type *PathError.
+// OpenFile is an alias for [os.OpenFile] on non-Windows platforms.
 func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	return os.OpenFile(name, flag, perm)
 }
 
-// CreateTemp creates a new temporary file in the directory dir
-// with a name beginning with prefix, opens the file for reading
-// and writing, and returns the resulting *os.File.
-// If dir is the empty string, TempFile uses the default directory
-// for temporary files (see os.TempDir).
-// Multiple programs calling TempFile simultaneously
-// will not choose the same file. The caller can use f.Name()
-// to find the pathname of the file. It is the caller's responsibility
-// to remove the file when no longer needed.
+// CreateTemp is an alias for [os.CreateTemp] on non-Windows platforms.
 func CreateTemp(dir, prefix string) (f *os.File, err error) {
 	return os.CreateTemp(dir, prefix)
 }

--- a/sequential/sequential_windows.go
+++ b/sequential/sequential_windows.go
@@ -35,15 +35,15 @@ func OpenFile(name string, flag int, _ os.FileMode) (*os.File, error) {
 	if name == "" {
 		return nil, &os.PathError{Op: "open", Path: name, Err: windows.ERROR_FILE_NOT_FOUND}
 	}
-	r, err := openFileSequential(name, flag, 0)
+	r, err := openFileSequential(name, flag)
 	if err == nil {
 		return r, nil
 	}
 	return nil, &os.PathError{Op: "open", Path: name, Err: err}
 }
 
-func openFileSequential(name string, flag int, _ os.FileMode) (file *os.File, err error) {
-	r, e := openSequential(name, flag|windows.O_CLOEXEC, 0)
+func openFileSequential(name string, flag int) (file *os.File, err error) {
+	r, e := openSequential(name, flag|windows.O_CLOEXEC)
 	if e != nil {
 		return nil, e
 	}
@@ -57,7 +57,7 @@ func makeInheritSa() *windows.SecurityAttributes {
 	return &sa
 }
 
-func openSequential(path string, mode int, _ uint32) (fd windows.Handle, err error) {
+func openSequential(path string, mode int) (fd windows.Handle, err error) {
 	if len(path) == 0 {
 		return windows.InvalidHandle, windows.ERROR_FILE_NOT_FOUND
 	}

--- a/sequential/sequential_windows.go
+++ b/sequential/sequential_windows.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
-	"syscall"
 	"time"
 	"unsafe"
 
@@ -18,7 +17,7 @@ import (
 // O_RDWR.
 // If there is an error, it will be of type *PathError.
 func Create(name string) (*os.File, error) {
-	return OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0)
+	return OpenFile(name, windows.O_RDWR|windows.O_CREAT|windows.O_TRUNC, 0)
 }
 
 // Open opens the named file for reading. If successful, methods on
@@ -26,7 +25,7 @@ func Create(name string) (*os.File, error) {
 // descriptor has mode O_RDONLY.
 // If there is an error, it will be of type *PathError.
 func Open(name string) (*os.File, error) {
-	return OpenFile(name, os.O_RDONLY, 0)
+	return OpenFile(name, windows.O_RDONLY, 0)
 }
 
 // OpenFile is the generalized open call; most users will use Open
@@ -34,7 +33,7 @@ func Open(name string) (*os.File, error) {
 // If there is an error, it will be of type *PathError.
 func OpenFile(name string, flag int, _ os.FileMode) (*os.File, error) {
 	if name == "" {
-		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.ENOENT}
+		return nil, &os.PathError{Op: "open", Path: name, Err: windows.ERROR_FILE_NOT_FOUND}
 	}
 	r, err := openFileSequential(name, flag, 0)
 	if err == nil {
@@ -145,7 +144,7 @@ func CreateTemp(dir, prefix string) (f *os.File, err error) {
 	nconflict := 0
 	for i := 0; i < 10000; i++ {
 		name := filepath.Join(dir, prefix+nextSuffix())
-		f, err = OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		f, err = OpenFile(name, windows.O_RDWR|windows.O_CREAT|windows.O_EXCL, 0o600)
 		if os.IsExist(err) {
 			if nconflict++; nconflict > 10 {
 				randmu.Lock()

--- a/sequential/sequential_windows.go
+++ b/sequential/sequential_windows.go
@@ -11,26 +11,35 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// Create creates the named file with mode 0666 (before umask), truncating
-// it if it already exists. If successful, methods on the returned
-// File can be used for I/O; the associated file descriptor has mode
-// O_RDWR.
-// If there is an error, it will be of type *PathError.
+// Create is a copy of [os.Create], modified to use sequential file access.
+//
+// It uses [windows.FILE_FLAG_SEQUENTIAL_SCAN] rather than [windows.FILE_ATTRIBUTE_NORMAL]
+// as implemented in golang. Refer to the [Win32 API documentation] for details
+// on sequential file access.
+//
+// [Win32 API documentation]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
 func Create(name string) (*os.File, error) {
 	return openFileSequential(name, windows.O_RDWR|windows.O_CREAT|windows.O_TRUNC)
 }
 
-// Open opens the named file for reading. If successful, methods on
-// the returned file can be used for reading; the associated file
-// descriptor has mode O_RDONLY.
-// If there is an error, it will be of type *PathError.
+// Open is a copy of [os.Open], modified to use sequential file access.
+//
+// It uses [windows.FILE_FLAG_SEQUENTIAL_SCAN] rather than [windows.FILE_ATTRIBUTE_NORMAL]
+// as implemented in golang. Refer to the [Win32 API documentation] for details
+// on sequential file access.
+//
+// [Win32 API documentation]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
 func Open(name string) (*os.File, error) {
 	return openFileSequential(name, windows.O_RDONLY)
 }
 
-// OpenFile is the generalized open call; most users will use Open
-// or Create instead.
-// If there is an error, it will be of type *PathError.
+// OpenFile is a copy of [os.OpenFile], modified to use sequential file access.
+//
+// It uses [windows.FILE_FLAG_SEQUENTIAL_SCAN] rather than [windows.FILE_ATTRIBUTE_NORMAL]
+// as implemented in golang. Refer to the [Win32 API documentation] for details
+// on sequential file access.
+//
+// [Win32 API documentation]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
 func OpenFile(name string, flag int, _ os.FileMode) (*os.File, error) {
 	return openFileSequential(name, flag)
 }
@@ -96,7 +105,7 @@ func openSequential(path string, mode int) (fd windows.Handle, err error) {
 		createmode = windows.OPEN_EXISTING
 	}
 	// Use FILE_FLAG_SEQUENTIAL_SCAN rather than FILE_ATTRIBUTE_NORMAL as implemented in golang.
-	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx
+	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
 	h, e := windows.CreateFile(pathp, access, sharemode, sa, createmode, windows.FILE_FLAG_SEQUENTIAL_SCAN, 0)
 	return h, e
 }
@@ -121,17 +130,13 @@ func nextSuffix() string {
 	return strconv.Itoa(int(1e9 + r%1e9))[1:]
 }
 
-// CreateTemp is a copy of os.CreateTemp, modified to use sequential
-// file access. Below is the original comment from golang:
-// TempFile creates a new temporary file in the directory dir
-// with a name beginning with prefix, opens the file for reading
-// and writing, and returns the resulting *os.File.
-// If dir is the empty string, TempFile uses the default directory
-// for temporary files (see os.TempDir).
-// Multiple programs calling TempFile simultaneously
-// will not choose the same file. The caller can use f.Name()
-// to find the pathname of the file. It is the caller's responsibility
-// to remove the file when no longer needed.
+// CreateTemp is a copy of [os.CreateTemp], modified to use sequential file access.
+//
+// It uses [windows.FILE_FLAG_SEQUENTIAL_SCAN] rather than [windows.FILE_ATTRIBUTE_NORMAL]
+// as implemented in golang. Refer to the [Win32 API documentation] for details
+// on sequential file access.
+//
+// [Win32 API documentation]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
 func CreateTemp(dir, prefix string) (f *os.File, err error) {
 	if dir == "" {
 		dir = os.TempDir()


### PR DESCRIPTION
### sequential: consistently use x/sys/windows for consts

Don't mix-and-mash packages for consts.

### sequential: open(File)Sequential: remove unused arg


### sequential: move error-handling to openFileSequential

Move the error-handling to openFileSequential and update exported functions to use openFileSequential instead of OpenFile().

### sequential: simplify docs for non-Windows implementations

The non-Windows implementations are aliases for the "os" stdlib package equivalents. This patch removes the local documentation, as it was out of date for some, and having the local documentation could give the impression that these functions were anything other than an alias.

<img width="1269" alt="Screenshot 2023-06-10 at 12 02 00" src="https://github.com/moby/sys/assets/1804568/217cd967-c788-48fd-bade-02bfb28b5574">

### sequential: update docs for Windows-implementation

Update the docs to refer to the "os" stdlib equivalents, and describe the changes compared to those, instead of replicating the os package's documentation.

<img width="1241" alt="Screenshot 2023-06-10 at 12 32 45" src="https://github.com/moby/sys/assets/1804568/40776ab1-87d8-43c2-a297-5d1a15488c8d">
