### PR TITLE
Bump CI to use supported go version, fix a single Go 1.20 issue in mount pkg; rm uneeded errorlint annotations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,12 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.17.x, 1.20.x, 1.21.x]
         platform: [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-11]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint: $(BINDIR)/golangci-lint
 	done
 
 $(BINDIR)/golangci-lint: $(BINDIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.45.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.55.1
 
 $(BINDIR):
 	mkdir -p $(BINDIR)

--- a/mount/go.mod
+++ b/mount/go.mod
@@ -4,5 +4,5 @@ go 1.17
 
 require (
 	github.com/moby/sys/mountinfo v0.6.2
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
+	golang.org/x/sys v0.1.0
 )

--- a/mount/go.mod
+++ b/mount/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/sys/mount
 
-go 1.16
+go 1.17
 
 require (
 	github.com/moby/sys/mountinfo v0.6.2

--- a/mount/go.sum
+++ b/mount/go.sum
@@ -1,4 +1,5 @@
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -23,7 +23,7 @@ func Mount(device, target, mType, options string) error {
 // a normal unmount. If target is not a mount point, no error is returned.
 func Unmount(target string) error {
 	err := unix.Unmount(target, mntDetach)
-	if err == nil || err == unix.EINVAL { //nolint:errorlint // unix errors are bare
+	if err == nil || err == unix.EINVAL {
 		// Ignore "not mounted" error here. Note the same error
 		// can be returned if flags are invalid, so this code
 		// assumes that the flags value is always correct.

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -71,7 +71,8 @@ func RecursiveUnmount(target string) error {
 		if err != nil {
 			if i == lastMount {
 				if suberr != nil {
-					return fmt.Errorf("%w (possible cause: %s)", err, suberr)
+					// TODO: switch to %w for suberr once we stop supporting go < 1.20.
+					return fmt.Errorf("%w (possible cause: %s)", err, suberr.Error())
 				}
 				return err
 			}

--- a/mountinfo/go.mod
+++ b/mountinfo/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/mountinfo
 
-go 1.16
+go 1.17
 
 require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a

--- a/mountinfo/go.mod
+++ b/mountinfo/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/mountinfo
 
 go 1.17
 
-require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
+require golang.org/x/sys v0.1.0

--- a/mountinfo/go.sum
+++ b/mountinfo/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/sequential/go.mod
+++ b/sequential/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/sequential
 
 go 1.17
 
-require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
+require golang.org/x/sys v0.1.0

--- a/sequential/go.sum
+++ b/sequential/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/sequential/sequential_windows.go
+++ b/sequential/sequential_windows.go
@@ -111,8 +111,10 @@ func openSequential(path string, mode int) (fd windows.Handle, err error) {
 }
 
 // Helpers for CreateTemp
-var rand uint32
-var randmu sync.Mutex
+var (
+	rand   uint32
+	randmu sync.Mutex
+)
 
 func reseed() uint32 {
 	return uint32(time.Now().UnixNano() + int64(os.Getpid()))

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/signal
 
 go 1.17
 
-require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
+require golang.org/x/sys v0.1.0

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/signal
 
-go 1.16
+go 1.17
 
 require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a

--- a/signal/go.sum
+++ b/signal/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/symlink/go.mod
+++ b/symlink/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/symlink
 
-go 1.16
+go 1.17
 
 require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a

--- a/symlink/go.mod
+++ b/symlink/go.mod
@@ -2,4 +2,4 @@ module github.com/moby/sys/symlink
 
 go 1.17
 
-require golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
+require golang.org/x/sys v0.1.0

--- a/symlink/go.sum
+++ b/symlink/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
1. Bump Go to supported version, other CI components.
2. Bump go to 1.17 in */go.mod.
3. Bump golang.org/x/sys to ~~v0.11.0.~~ v.0.1.0.
4. mount: fix an errorlint issue with Go 1.20+.
5. mount: rm unneeded errorlint annotations (thanks to https://github.com/polyfloyd/go-errorlint/pull/47).
6. sequential: fix a formatting issue (file is not gofumpt'ed)