### PR TITLE
integrate github.com/moby/buildkit/util/appcontext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES ?= mountinfo mount sequential signal symlink
+PACKAGES ?= appcontext mountinfo mount sequential signal symlink
 BINDIR ?= _build/bin
 CROSS ?= linux/arm linux/arm64 linux/ppc64le linux/s390x \
 	freebsd/amd64 openbsd/amd64 darwin/amd64 darwin/arm64 windows/amd64

--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -1,0 +1,46 @@
+package appcontext
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/moby/buildkit/util/bklog"
+)
+
+var appContextCache context.Context
+var appContextOnce sync.Once
+
+// Context returns a static context that reacts to termination signals of the
+// running process. Useful in CLI tools.
+func Context() context.Context {
+	appContextOnce.Do(func() {
+		signals := make(chan os.Signal, 2048)
+		signal.Notify(signals, terminationSignals...)
+
+		const exitLimit = 3
+		retries := 0
+
+		ctx := context.Background()
+		for _, f := range inits {
+			ctx = f(ctx)
+		}
+
+		ctx, cancel := context.WithCancel(ctx)
+		appContextCache = ctx
+
+		go func() {
+			for {
+				<-signals
+				cancel()
+				retries++
+				if retries >= exitLimit {
+					bklog.G(ctx).Errorf("got %d SIGTERM/SIGINTs, forcing shutdown", retries)
+					os.Exit(1)
+				}
+			}
+		}()
+	})
+	return appContextCache
+}

--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-
-	"github.com/moby/buildkit/util/bklog"
 )
 
 var appContextCache context.Context
@@ -36,7 +34,6 @@ func Context() context.Context {
 				cancel()
 				retries++
 				if retries >= exitLimit {
-					bklog.G(ctx).Errorf("got %d SIGTERM/SIGINTs, forcing shutdown", retries)
 					os.Exit(1)
 				}
 			}

--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -7,8 +7,10 @@ import (
 	"sync"
 )
 
-var appContextCache context.Context
-var appContextOnce sync.Once
+var (
+	appContextCache context.Context
+	appContextOnce  sync.Once
+)
 
 // Context returns a static context that reacts to termination signals of the
 // running process. Useful in CLI tools.

--- a/appcontext/appcontext_unix.go
+++ b/appcontext/appcontext_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+// +build !windows
+
+package appcontext
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+var terminationSignals = []os.Signal{unix.SIGTERM, unix.SIGINT}

--- a/appcontext/appcontext_windows.go
+++ b/appcontext/appcontext_windows.go
@@ -1,0 +1,7 @@
+package appcontext
+
+import (
+	"os"
+)
+
+var terminationSignals = []os.Signal{os.Interrupt}

--- a/appcontext/go.mod
+++ b/appcontext/go.mod
@@ -1,0 +1,5 @@
+module github.com/moby/sys/appcontext
+
+go 1.17
+
+require golang.org/x/sys v0.11.0

--- a/appcontext/go.sum
+++ b/appcontext/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/appcontext/register.go
+++ b/appcontext/register.go
@@ -1,0 +1,14 @@
+package appcontext
+
+import (
+	"context"
+)
+
+type Initializer func(context.Context) context.Context
+
+var inits []Initializer
+
+// Register stores a new context initializer that runs on app context creation
+func Register(f Initializer) {
+	inits = append(inits, f)
+}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4457

`appcontext` pkg is used across repos and it would be useful to have it as a dedicated module: https://grep.app/search?q=github.com/moby/buildkit/util/appcontext

Specially for `docker/cli` as this is the only package left depending on buildkit: https://github.com/docker/cli/blob/f74f88445f8b23fe4804f1072e5f376cfbe46487/cmd/docker/docker.go#L17

Taken from https://github.com/moby/buildkit/tree/master/util/appcontext commit https://github.com/moby/buildkit/commit/05eb7287534b785822c8cc6c8530f5a6d9609162 with history.