### PR TITLE
add _build to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/_build/
 /mount/go-local.*


### PR DESCRIPTION
When running golangci-lint locally (make lint), it compiles the golangci-lint binary in BINDIR, which defaults to _build/bin inside the repository.