### PR TITLE
ci/gha: add Go 1.22, update various actions, add macos-12, ubuntu-24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: go mod tidy
       run: |
         make tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.x, 1.20.x, 1.21.x]
-        platform: [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-11]
+        platform: [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-12]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.20.x, 1.21.x]
+        go-version: [1.17.x, 1.21.x, 1.22.x]
         platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-12, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.x, 1.20.x, 1.21.x]
-        platform: [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-12]
+        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-12]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.x, 1.20.x, 1.21.x]
-        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-12]
+        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-12, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint: $(BINDIR)/golangci-lint
 	done
 
 $(BINDIR)/golangci-lint: $(BINDIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.55.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.59.1
 
 $(BINDIR):
 	mkdir -p $(BINDIR)

--- a/mountinfo/mounted_linux.go
+++ b/mountinfo/mounted_linux.go
@@ -51,7 +51,7 @@ func mountedByOpenat2(path string) (bool, error) {
 		Resolve: unix.RESOLVE_NO_XDEV,
 	})
 	_ = unix.Close(dirfd)
-	switch err { //nolint:errorlint // unix errors are bare
+	switch err {
 	case nil: // definitely not a mount
 		_ = unix.Close(fd)
 		return false, nil

--- a/user/user.go
+++ b/user/user.go
@@ -197,7 +197,6 @@ func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
 		for {
 			var line []byte
 			line, isPrefix, err = rd.ReadLine()
-
 			if err != nil {
 				// We should return no error if EOF is reached
 				// without a match.


### PR DESCRIPTION
- follow-up https://github.com/moby/sys/pull/129#issuecomment-2205339496

### user: gofumpt

### ci/gha: remove macos-11 (deprecated), update to macos-12

From the GitHub actions documentation [1];

> The macos-11 label has been deprecated and will no longer be available
> after 28 June 2024.

[1]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories



### ci/gha: bump actions/setup-go to v5

Upgrades Node.js runtime from node16 to node20

### ci/gha: bump actions/checkout to v4

Only a single commit is fetched by default, for the ref/SHA that triggered
the workflow. Set fetch-depth: 0 to fetch all history for all branches and
tags.


### Makefile: bump golangci-lint to v1.59.1

### mountinfo: rm unneeded errorlint annotation

Commit d6a52098207d17e40c2247f7893626b5e07045f5 removed most errorlint
annotations, with one remaining.

golangci-lint v1.59.1 comes with errorlint v1.5.2, which contains
the fix [2] whitelisting all errno comparisons for errors coming from
x/sys/unix. Remove the annotation that is no longer needed.


[2]: https://github.com/polyfloyd/go-errorlint/commit/c0e6cac0ec994c118a788505f20fbb20d2b38c11


### ci/gha: add ubuntu-24.04 (current LTS)

Ubuntu 24.04 runners are now available (see [3])

[3]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

### ci/gha: add macos-14 (m1, arm64)

Add current macOS version, running on arm64  (see [4])

[4]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories


### ci/gha: drop Go 1.20, add Go 1.22

Test with the current stable version of Go; keeping Go 1.17 as lower
boundary for now since it costs us little to keep supporting it.
