### PR TITLE
update to go1.18, and use strings.Cut

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.21.x, 1.22.x]
+        go-version: [1.18.x, 1.21.x, 1.22.x]
         platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-12, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/mount/flags_unix.go
+++ b/mount/flags_unix.go
@@ -100,14 +100,14 @@ func MergeTmpfsOptions(options []string) ([]string, error) {
 			}
 			continue
 		}
-		opt := strings.SplitN(option, "=", 2)
-		if len(opt) != 2 || !validFlags[opt[0]] {
+		opt, _, ok := strings.Cut(option, "=")
+		if !ok || !validFlags[opt] {
 			return nil, fmt.Errorf("invalid tmpfs option %q", opt)
 		}
-		if !dataCollisions[opt[0]] {
+		if !dataCollisions[opt] {
 			// We prepend the option and add to collision map
 			newOptions = append([]string{option}, newOptions...)
-			dataCollisions[opt[0]] = true
+			dataCollisions[opt] = true
 		}
 	}
 

--- a/mount/go.mod
+++ b/mount/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/sys/mount
 
-go 1.17
+go 1.18
 
 require (
 	github.com/moby/sys/mountinfo v0.7.2

--- a/mount/mounter_linux_test.go
+++ b/mount/mounter_linux_test.go
@@ -212,7 +212,8 @@ func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 
 // clean strips off any value param after the colon
 func clean(v string) string {
-	return strings.SplitN(v, ":", 2)[0]
+	out, _, _ := strings.Cut(v, ":")
+	return out
 }
 
 // has returns true if key is a member of m

--- a/mountinfo/go.mod
+++ b/mountinfo/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/mountinfo
 
-go 1.17
+go 1.18
 
 require golang.org/x/sys v0.1.0

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -81,10 +81,13 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		}
 
 		p := &Info{
-			ID:     toInt(fields[0]),
-			Parent: toInt(fields[1]),
-			Major:  toInt(major),
-			Minor:  toInt(minor),
+			ID:         toInt(fields[0]),
+			Parent:     toInt(fields[1]),
+			Major:      toInt(major),
+			Minor:      toInt(minor),
+			Options:    fields[5],
+			Optional:   strings.Join(fields[6:sepIdx], " "), // zero or more optional fields
+			VFSOptions: fields[sepIdx+3],
 		}
 
 		p.Mountpoint, err = unescape(fields[4])
@@ -99,17 +102,11 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parsing '%s' failed: source: %w", fields[sepIdx+2], err)
 		}
-		p.VFSOptions = fields[sepIdx+3]
 
 		p.Root, err = unescape(fields[3])
 		if err != nil {
 			return nil, fmt.Errorf("parsing '%s' failed: root: %w", fields[3], err)
 		}
-
-		p.Options = fields[5]
-
-		// zero or more optional fields
-		p.Optional = strings.Join(fields[6:sepIdx], " ")
 
 		// Run the filter after parsing all fields.
 		var skip, stop bool

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -75,9 +75,16 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 			}
 		}
 
+		major, minor, ok := strings.Cut(fields[2], ":")
+		if !ok {
+			return nil, fmt.Errorf("parsing '%s' failed: unexpected major:minor pair %s", text, fields[2])
+		}
+
 		p := &Info{
 			ID:     toInt(fields[0]),
 			Parent: toInt(fields[1]),
+			Major:  toInt(major),
+			Minor:  toInt(minor),
 		}
 
 		p.Mountpoint, err = unescape(fields[4])
@@ -93,13 +100,6 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 			return nil, fmt.Errorf("parsing '%s' failed: source: %w", fields[sepIdx+2], err)
 		}
 		p.VFSOptions = fields[sepIdx+3]
-
-		mm := strings.SplitN(fields[2], ":", 3)
-		if len(mm) != 2 {
-			return nil, fmt.Errorf("parsing '%s' failed: unexpected major:minor pair %s", text, mm)
-		}
-		p.Major = toInt(mm[0])
-		p.Minor = toInt(mm[1])
 
 		p.Root, err = unescape(fields[3])
 		if err != nil {

--- a/mountinfo/mountinfo_linux.go
+++ b/mountinfo/mountinfo_linux.go
@@ -75,7 +75,10 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 			}
 		}
 
-		p := &Info{}
+		p := &Info{
+			ID:     toInt(fields[0]),
+			Parent: toInt(fields[1]),
+		}
 
 		p.Mountpoint, err = unescape(fields[4])
 		if err != nil {
@@ -91,15 +94,12 @@ func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		}
 		p.VFSOptions = fields[sepIdx+3]
 
-		// ignore any numbers parsing errors, as there should not be any
-		p.ID, _ = strconv.Atoi(fields[0])
-		p.Parent, _ = strconv.Atoi(fields[1])
 		mm := strings.SplitN(fields[2], ":", 3)
 		if len(mm) != 2 {
 			return nil, fmt.Errorf("parsing '%s' failed: unexpected major:minor pair %s", text, mm)
 		}
-		p.Major, _ = strconv.Atoi(mm[0])
-		p.Minor, _ = strconv.Atoi(mm[1])
+		p.Major = toInt(mm[0])
+		p.Minor = toInt(mm[1])
 
 		p.Root, err = unescape(fields[3])
 		if err != nil {
@@ -247,4 +247,11 @@ func unescape(path string) (string, error) {
 	}
 
 	return string(buf[:bufLen]), nil
+}
+
+// toInt converts a string to an int, and ignores any numbers parsing errors,
+// as there should not be any.
+func toInt(s string) int {
+	i, _ := strconv.Atoi(s)
+	return i
 }

--- a/sequential/go.mod
+++ b/sequential/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/sequential
 
-go 1.17
+go 1.18
 
 require golang.org/x/sys v0.1.0

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/signal
 
-go 1.17
+go 1.18
 
 require golang.org/x/sys v0.1.0

--- a/symlink/go.mod
+++ b/symlink/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/symlink
 
-go 1.17
+go 1.18
 
 require golang.org/x/sys v0.1.0

--- a/user/go.mod
+++ b/user/go.mod
@@ -1,5 +1,5 @@
 module github.com/moby/sys/user
 
-go 1.17
+go 1.18
 
 require golang.org/x/sys v0.1.0


### PR DESCRIPTION
### *: update minimum go version to go1.18

This allows us to start using some new features, like strings.Cut

### mount: MergeTmpfsOptions : use strings.Cut

it's faster, and uses less allocations.

### mountinfo: add "toInt()" utility

### mountinfo: GetMountsFromReader: use strings.Cut

It's faster, and reduces 410 allocations (1976 -> 1566).

Before:

    go test -v -test.benchmem -count=10 -run ^$ -bench BenchmarkParseMountinfo .
    go: downloading golang.org/x/sys v0.1.0
    goos: linux
    goarch: arm64
    pkg: github.com/moby/sys/mountinfo
    BenchmarkParseMountinfo
    BenchmarkParseMountinfo-10        4405    283442 ns/op  245426 B/op    1976 allocs/op
    BenchmarkParseMountinfo-10        4180    258441 ns/op  245425 B/op    1976 allocs/op
    BenchmarkParseMountinfo-10        4146    258770 ns/op  245425 B/op    1976 allocs/op
    BenchmarkParseMountinfo-10        4180    259924 ns/op  245425 B/op    1976 allocs/op
    BenchmarkParseMountinfo-10        4162    263537 ns/op  245425 B/op    1976 allocs/op
    BenchmarkParseMountinfo-10        4218    261200 ns/op  245425 B/op    1976 allocs/op
    BenchmarkParseMountinfo-10        4746    259271 ns/op  245425 B/op    1976 allocs/op
    BenchmarkParseMountinfo-10        4362    265330 ns/op  245425 B/op    1976 allocs/op
    BenchmarkParseMountinfo-10        4454    263110 ns/op  245425 B/op    1976 allocs/op
    BenchmarkParseMountinfo-10        4134    266847 ns/op  245425 B/op    1976 allocs/op
    PASS
    ok  github.com/moby/sys/mountinfo 11.653s

After

    go test -v -test.benchmem -count=10 -run ^$ -bench BenchmarkParseMountinfo .
    go: downloading golang.org/x/sys v0.1.0
    goos: linux
    goarch: arm64
    pkg: github.com/moby/sys/mountinfo
    BenchmarkParseMountinfo
    BenchmarkParseMountinfo-10        4544    262155 ns/op  225746 B/op    1566 allocs/op
    BenchmarkParseMountinfo-10        4447    266108 ns/op  225745 B/op    1566 allocs/op
    BenchmarkParseMountinfo-10        4522    246329 ns/op  225745 B/op    1566 allocs/op
    BenchmarkParseMountinfo-10        4311    249786 ns/op  225745 B/op    1566 allocs/op
    BenchmarkParseMountinfo-10        4612    250989 ns/op  225745 B/op    1566 allocs/op
    BenchmarkParseMountinfo-10        4588    249702 ns/op  225745 B/op    1566 allocs/op
    BenchmarkParseMountinfo-10        4342    247774 ns/op  225745 B/op    1566 allocs/op
    BenchmarkParseMountinfo-10        4530    246963 ns/op  225745 B/op    1566 allocs/op
    BenchmarkParseMountinfo-10        4690    248594 ns/op  225745 B/op    1566 allocs/op
    BenchmarkParseMountinfo-10        4455    254278 ns/op  225745 B/op    1566 allocs/op
    PASS
    ok  github.com/moby/sys/mountinfo 11.660s


### mountinfo: GetMountsFromReader: inline some assignments

