### PR TITLE
mountinfo: simpify, speedup, and fix unescape

### DIFF
--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -731,43 +731,41 @@ func TestParseMountinfoExtraCases(t *testing.T) {
 }
 
 func TestUnescape(t *testing.T) {
+	// When adding test cases below, be aware that Go interprets \NNN
+	// inside strings enclosed in double quotes in the same way as the
+	// function being tested, so:
+	//  - for input: either escape every backslash character (i.e. \\), or
+	//    enclose the whole string in `backticks` so \NNN is passed as-is;
+	//  - for output: write it like "\040", which is identical to " ".
 	testCases := []struct {
 		input, output string
-		isErr         bool
 	}{
-		{"", "", false},
-		{"/", "/", false},
-		{"/some/longer/path", "/some/longer/path", false},
-		{"/path\\040with\\040spaces", "/path with spaces", false},
-		{"/path/with\\134backslash", "/path/with\\backslash", false},
-		{"/tab\\011in/path", "/tab\tin/path", false},
-		{`/path/"with'quotes`, `/path/"with'quotes`, false},
-		{`/path/"with'quotes,\040space,\011tab`, `/path/"with'quotes, space,	tab`, false},
-		{`\12`, "", true},
-		{`\134`, `\`, false},
-		{`"'"'"'`, `"'"'"'`, false},
-		{`/\1345`, `/\5`, false},
-		{`/\12x`, "", true},
-		{`\0`, "", true},
-		{`\x`, "", true},
-		{"\\\\", "", true},
+		{"", ""},
+		{"/", "/"},
+		{"/some/longer/path", "/some/longer/path"},
+		{`/path\040with\040spaces`, "/path\040with\040spaces"},
+		{"/path/with\\134backslash", "/path/with\\backslash"},
+		{"/tab\\011in/path", "/tab\011in/path"},
+		{`/path/"with'quotes`, `/path/"with'quotes`},
+		{`/path/"with'quotes,\040space,\011tab`, `/path/"with'quotes, space,	tab`},
+		{`\12`, `\12`}, // Not enough digits.
+		{`\134`, `\`},  // Backslash.
+		{`"'"'"'`, `"'"'"'`},
+		{`/\1345`, `/\5`}, // Backslash with extra digit.
+		{`/\12x`, `/\12x`},
+		{`\0`, `\0`},             // Not enough digits.
+		{`\000\000`, "\000\000"}, // NUL (min allowed ASCII value).
+		{`\x`, `\x`},
+		{"\\\\", "\\\\"},
+		{`\177`, "\177"}, // Max allowed ASCII value.
+		{`\222`, `\222`}, // Too large value -- not unescaped.
+		{`Это\040комон\040какой-то`, "Это комон какой-то"}, // Some UTF-8 -- not unescaped.
 	}
 
 	for _, tc := range testCases {
-		res, err := unescape(tc.input)
-		if tc.isErr == true {
-			if err == nil {
-				t.Errorf("Input %q, want error, got nil", tc.input)
-			}
-			// no more checks
-			continue
-		}
+		res := unescape(tc.input)
 		if res != tc.output {
 			t.Errorf("Input %q, want %q, got %q", tc.input, tc.output, res)
-		}
-		if err != nil {
-			t.Errorf("Input %q, want nil, got error %v", tc.input, err)
-			continue
 		}
 	}
 }
@@ -796,7 +794,7 @@ func BenchmarkUnescape(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		for x := 0; x < len(testCases); x++ {
-			_, _ = unescape(testCases[x])
+			_ = unescape(testCases[x])
 		}
 	}
 }

--- a/mountinfo/mountinfo_linux_test.go
+++ b/mountinfo/mountinfo_linux_test.go
@@ -771,3 +771,32 @@ func TestUnescape(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkUnescape(b *testing.B) {
+	testCases := []string{
+		"",
+		"/",
+		"/some/longer/path",
+		"/path\\040with\\040spaces",
+		"/path/with\\134backslash",
+		"/tab\\011in/path",
+		`/path/"with'quotes`,
+		`/path/"with'quotes,\040space,\011tab`,
+		`\12`,
+		`\134`,
+		`"'"'"'`,
+		`/\1345`,
+		`/\12x`,
+		`\0`,
+		`\x`,
+		"\\\\",
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for x := 0; x < len(testCases); x++ {
+			_, _ = unescape(testCases[x])
+		}
+	}
+}


### PR DESCRIPTION
This is an alternative to #143.

It has been pointed out that unescape implementation is unnecessarily
complex, and I tend to agree. Plus, we never expect any errors during
unescaping, and if there are any, we can always return the string as is.

So, drop the error return, and simplify the algorithm. Modify the test
case and the benchmark accordingly.

NOTE this also fixes the issue of trying to convert escape sequences
where the character code is >= `utf8.RuneSelf` (128 decimal, 0200 octal).
Adding those to the output may result in invalid utf-8 strings. The new
code doesn't try to unescape those (and the tests are amended to check
that).

Add some more test cases.

Here's benchstat output:
```
name               old time/op    new time/op    delta
Unescape-20           851ns ± 1%     358ns ± 3%  -57.94%  (p=0.008 n=5+5)

name               old alloc/op   new alloc/op   delta
Unescape-20            640B ± 0%      255B ± 0%  -60.16%  (p=0.000 n=5+4)

name               old allocs/op  new allocs/op  delta
Unescape-20            31.0 ± 0%      21.0 ± 0%  -32.26%  (p=0.008 n=5+5)
```