### PR TITLE
Add Go 1.23, drop 1.21, bump golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.21.x, 1.22.x]
+        go-version: [1.18.x, 1.22.x, 1.23.x]
         platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-12, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint: $(BINDIR)/golangci-lint
 	done
 
 $(BINDIR)/golangci-lint: $(BINDIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.59.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.60.1
 
 $(BINDIR):
 	mkdir -p $(BINDIR)


### PR DESCRIPTION
Add Go 1.23, drop 1.21.

Also, bump golangci-lint to v1.60.1 (which adds Go 1.23 support).

A draft pending #144 merge.
