### PR TITLE
Add go fix to CI, rm old build tags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,11 @@ jobs:
         echo 'PACKAGES="mountinfo mount sequential signal symlink user"' >> $GITHUB_ENV
     - name: go mod tidy
       run: |
-        make tidy
+        make foreach CMD="go mod tidy"
+        git diff --exit-code
+    - name: go fix
+      run: |
+        make foreach CMD="go fix"
         git diff --exit-code
     - name: Lint
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,6 @@ test: test-local
 test: CMD=go test $(RUN_VIA_SUDO) -v .
 test: foreach
 
-.PHONY: tidy
-tidy: CMD=go mod tidy
-tidy: foreach
-
 # Test the mount module against the local mountinfo source code instead of the
 # release specified in its go.mod. This allows catching regressions / breaking
 # changes in mountinfo.

--- a/mount/flags_bsd.go
+++ b/mount/flags_bsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd || openbsd
-// +build freebsd openbsd
 
 package mount
 

--- a/mount/flags_unix.go
+++ b/mount/flags_unix.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package mount
 

--- a/mount/mount_errors.go
+++ b/mount/mount_errors.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package mount
 

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package mount
 

--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package mount
 

--- a/mount/mounter_freebsd.go
+++ b/mount/mounter_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd && cgo
-// +build freebsd,cgo
 
 package mount
 

--- a/mount/mounter_openbsd.go
+++ b/mount/mounter_openbsd.go
@@ -1,5 +1,4 @@
 //go:build openbsd && cgo
-// +build openbsd,cgo
 
 /*
    Due to how OpenBSD mount(2) works, filesystem types need to be

--- a/mount/mounter_unsupported.go
+++ b/mount/mounter_unsupported.go
@@ -1,5 +1,4 @@
 //go:build (!linux && !freebsd && !openbsd && !windows && !darwin) || (freebsd && !cgo) || (openbsd && !cgo)
-// +build !linux,!freebsd,!openbsd,!windows,!darwin freebsd,!cgo openbsd,!cgo
 
 package mount
 

--- a/mountinfo/mounted_unix.go
+++ b/mountinfo/mounted_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd || openbsd || darwin
-// +build linux freebsd openbsd darwin
 
 package mountinfo
 

--- a/mountinfo/mountinfo_bsd.go
+++ b/mountinfo/mountinfo_bsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd || openbsd || darwin
-// +build freebsd openbsd darwin
 
 package mountinfo
 

--- a/mountinfo/mountinfo_freebsdlike.go
+++ b/mountinfo/mountinfo_freebsdlike.go
@@ -1,5 +1,4 @@
 //go:build freebsd || darwin
-// +build freebsd darwin
 
 package mountinfo
 

--- a/mountinfo/mountinfo_test.go
+++ b/mountinfo/mountinfo_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package mountinfo
 

--- a/mountinfo/mountinfo_unsupported.go
+++ b/mountinfo/mountinfo_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux && !freebsd && !openbsd && !darwin
-// +build !windows,!linux,!freebsd,!openbsd,!darwin
 
 package mountinfo
 

--- a/sequential/sequential_unix.go
+++ b/sequential/sequential_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package sequential
 

--- a/signal/signal_linux.go
+++ b/signal/signal_linux.go
@@ -1,5 +1,4 @@
 //go:build !mips && !mipsle && !mips64 && !mips64le
-// +build !mips,!mipsle,!mips64,!mips64le
 
 package signal
 

--- a/signal/signal_linux_mipsx.go
+++ b/signal/signal_linux_mipsx.go
@@ -1,6 +1,4 @@
 //go:build linux && (mips || mipsle || mips64 || mips64le)
-// +build linux
-// +build mips mipsle mips64 mips64le
 
 package signal
 

--- a/signal/signal_linux_test.go
+++ b/signal/signal_linux_test.go
@@ -1,5 +1,4 @@
 //go:build darwin || linux
-// +build darwin linux
 
 package signal
 

--- a/signal/signal_unix.go
+++ b/signal/signal_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package signal
 

--- a/signal/signal_unsupported.go
+++ b/signal/signal_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin && !freebsd && !windows
-// +build !linux,!darwin,!freebsd,!windows
 
 package signal
 

--- a/symlink/fs_unix.go
+++ b/symlink/fs_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package symlink
 

--- a/symlink/fs_unix_test.go
+++ b/symlink/fs_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Licensed under the Apache License, Version 2.0; See LICENSE.APACHE
 


### PR DESCRIPTION
This removes old (Go < 1.17) build tags, and makes sure CI runs `go fix` (which, unfortunately, is not part of any linter).