### PR TITLE
capability: add LastCap stub for non-Linux

### DIFF
--- a/capability/capability.go
+++ b/capability/capability.go
@@ -132,3 +132,9 @@ func NewFile(path string) (Capabilities, error) {
 func NewFile2(path string) (Capabilities, error) {
 	return newFile(path)
 }
+
+// LastCap returns highest valid capability of the running kernel,
+// or an error if it can not be obtained.
+func LastCap() (Cap, error) {
+	return lastCap()
+}

--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -25,11 +25,6 @@ const (
 	linuxCapVer3 = 0x20080522
 )
 
-// LastCap returns highest valid capability of the running kernel.
-func LastCap() (Cap, error) {
-	return lastCap()
-}
-
 var lastCap = sync.OnceValues(func() (Cap, error) {
 	f, err := os.Open("/proc/sys/kernel/cap_last_cap")
 	if err != nil {

--- a/capability/capability_noop.go
+++ b/capability/capability_noop.go
@@ -11,10 +11,12 @@ package capability
 
 import "errors"
 
-func newPid(pid int) (Capabilities, error) {
-	return nil, errors.New("not supported")
+var errNotSup = errors.New("not supported")
+
+func newPid(_ int) (Capabilities, error) {
+	return nil, errNotSup
 }
 
-func newFile(path string) (Capabilities, error) {
-	return nil, errors.New("not supported")
+func newFile(_ string) (Capabilities, error) {
+	return nil, errNotSup
 }

--- a/capability/capability_noop.go
+++ b/capability/capability_noop.go
@@ -20,3 +20,7 @@ func newPid(_ int) (Capabilities, error) {
 func newFile(_ string) (Capabilities, error) {
 	return nil, errNotSup
 }
+
+func lastCap() (Cap, error) {
+	return -1, errNotSup
+}

--- a/capability/capability_test.go
+++ b/capability/capability_test.go
@@ -4,15 +4,26 @@
 
 package capability
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func TestLastCap(t *testing.T) {
 	last, err := LastCap()
-	if err != nil {
-		t.Fatal(err)
+	switch runtime.GOOS {
+	case "linux":
+		if err != nil {
+			t.Fatal(err)
+		}
+	default:
+		if err == nil {
+			t.Fatal(runtime.GOOS, ": want error, got nil")
+		}
+		return
 	}
 
-	// Sanity checks.
+	// Sanity checks (Linux only).
 	//
 	// Based on the fact Go 1.18+ supports Linux >= 2.6.32, and
 	//   - CAP_MAC_ADMIN (33) was added in 2.6.25;


### PR DESCRIPTION
So that the code which uses capability.LastCap can be compiled on
non-Linux platforms.

Found the issue while working on https://github.com/containers/common/pull/2167
