### PR TITLE
ci: add path to go.sum to actions/setup-go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,20 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Find go.sum files
+      id: gosum
+      shell: bash
+      run: |
+        echo 'files<<EOF' >> "$GITHUB_OUTPUT"
+        git ls-files '*/go.sum' >> "$GITHUB_OUTPUT"
+        echo 'EOF' >> "$GITHUB_OUTPUT"
     - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v4
+        cache-dependency-path: ${{ steps.gosum.outputs.files }}
     - name: Set PACKAGES env
       if: ${{ matrix.go-version == '1.18.x' }}
       run: |


### PR DESCRIPTION

I just noticed that actions/setup-go complains about the missing
go.sum file:

>  Restore cache failed: Dependencies file is not found in /home/runner/work/sys/sys. Supported file pattern: go.sum

Apparently this happens because of two reasons:

 1. actions/checkout should be run _before actions/setup-go.

 2. There's no top-level go.sum file.

The first problem is easy to fix.

As for the second one, documentation[1] suggests using a wild card in
such cases, but using neither "*/go.sum" nor "**/go.sum" works, as not
all modules have go.sum, and so it fails with the following error:

> Restore cache failed: Some specified paths were not resolved, unable to cache dependencies.

Alas, we have to add an extra step to list the available go.sum files.
The alternative would be listing them all, which is maintainers' nightmare.

(The contents of these files are used as an input when calculating the
cache checksum, essentially meaning if any of these files are changed,
the cache will be invalidated.)

[1]: https://github.com/actions/setup-go/blob/main/README.md#caching-dependency-files-and-build-outputs
