### PR TITLE
ci: checkout first, disable go caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,16 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
     - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v4
+        # Disable caching as we don't have top-level go.sum needed for
+        # the cache key, and specifying multiple go.sums is not trivial
+        # (see https://github.com/moby/sys/pull/160 for details).
+        cache: false
     - name: Set PACKAGES env
       if: ${{ matrix.go-version == '1.18.x' }}
       run: |


### PR DESCRIPTION
_This is an alternative to #155._

----

First, checking out the code should be done before installing Go.

Second, since we don't have top-level `go.mod`, actions/setup-go complains:

> Restore cache failed: Dependencies file is not found in /home/runner/work/sys/sys. Supported file pattern: go.sum

One way to solve this would be to add

```yml
cache-dependency-path: "*/go.sum"
```

parameter to `actions/setup-go`. Alas it won't work because not all modules here have go.mod, and * in GHA is not what you think it is (i.e. not a part of shell glob pattern, but rather "every directory"), and as a result it complains about missing go.sum files.

Another way is to list all the paths explicitly, which is not good from the maintainability perspective (someone will definitely forgot to add a go.sum path).

Yet another way is to add a step which lists all go.sum. It works something like this:

```yml
            - name: Find go.sum files
              id: gosum
              run: |
              echo 'files<<EOF' >> "$GITHUB_OUTPUT"
              git ls-files '*/go.sum' >> "$GITHUB_OUTPUT"
              echo 'EOF' >> "$GITHUB_OUTPUT"
    
            ...
            - name: Install Go
              uses: actions/setup-go@v5
                with:
                  cache-dependency-path: ${{ steps.gosum.outputs.files }}

```

But given the fact that caching is not doing much here (as we don't have a lot of code) it's becoming too complicated with not much to gain.

So, let's just disable Go caching, so the warning above will go away.