### PR TITLE
capability: add separate API for ambient capabilities

### DIFF
--- a/capability/capability.go
+++ b/capability/capability.go
@@ -142,3 +142,18 @@ func NewFile2(path string) (Capabilities, error) {
 func LastCap() (Cap, error) {
 	return lastCap()
 }
+
+// AmbientRaise raises specified ambient capabilities for the calling process.
+func AmbientRaise(cap ...Cap) error {
+	return ambientRaise(cap...)
+}
+
+// AmbientLower lowers specified ambient capabilities for the calling process.
+func AmbientLower(cap ...Cap) error {
+	return ambientLower(cap...)
+}
+
+// AmbientClearAll lowers all ambient capabilities for the calling process.
+func AmbientClearAll() error {
+	return ambientClearAll()
+}

--- a/capability/capability_noop.go
+++ b/capability/capability_noop.go
@@ -24,3 +24,15 @@ func newFile(_ string) (Capabilities, error) {
 func lastCap() (Cap, error) {
 	return -1, errNotSup
 }
+
+func ambientRaise(cap ...Cap) error {
+	return errNotSup
+}
+
+func ambientLower(cap ...Cap) error {
+	return errNotSup
+}
+
+func ambientClearAll() error {
+	return errNotSup
+}


### PR DESCRIPTION
In runtime-spec said[1]:
Runtimes SHOULD NOT fail if the container configuration requests capabilities that cannot be granted, for example, if the runtime operates in a restricted environment with a limited set of capabilities.
So this is the default mode when requesting capabilities. As a package used by `runc`, I think most of code about capabilities should be in this project, not in runc.

For the first edition of ambient implementation, though it masked the err because of a bug, but there was no `return` when got an error, it is different from the error handling in other place, so I think it was the author's original ideal to raise as many ambient cap sets as possible when got some errors.
There is no return in ambient caps apply:
https://github.com/moby/sys/blob/7b553f586f4d8789de3a26d20fb0beecb08b52bf/capability/capability/capability_linux.go#L477-L482
There is a return in other place:
https://github.com/moby/sys/blob/7b553f586f4d8789de3a26d20fb0beecb08b52bf/capability/capability/capability_linux.go#L451-L459

~~So, I think we should provide a choice to let users make the decision, for ambient cap sets apply, we should provide at least two modes:~~
~~1. Greedy mode: it should be the default mode to be compatible with the past, it means raise ambient caps as many as possible and return the last error;~~
~~2. Stop on error mode: it means that we should stop to raise other ambient caps when got an error.~~

So, I think we should provide the abilities to let users can make a decision to ignore the ambient cap raise/lower error or not.

[1] https://github.com/opencontainers/runtime-spec/blob/8f3fbc881602d85699e5c448634ec1288860d966/config.md?plain=1#L286-L292