### PR TITLE
Update macOS runner image to macOS 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.x, 1.22.x, 1.23.x]
-        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-12, macos-14]
+        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-13, macos-14]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:


### PR DESCRIPTION
macOS 12 runners are being deprecated. See https://github.com/actions/runner-images/issues/10721

This change upgrades the macOS runner image to macOS 13.