### PR TITLE
capability: can't raise ambient and drop bounding caps for other process

### DIFF
--- a/capability/capability.go
+++ b/capability/capability.go
@@ -8,6 +8,8 @@
 // Package capability provides utilities for manipulating POSIX capabilities.
 package capability
 
+import "errors"
+
 type Capabilities interface {
 	// Get check whether a capability present in the given
 	// capabilities set. The 'which' value should be one of EFFECTIVE,
@@ -60,6 +62,11 @@ type Capabilities interface {
 	// effect.
 	Apply(kind CapType) error
 }
+
+var (
+	errBoundingNotMine = errors.New("not support drop bounding cap of other process")
+	errAmbientNotMine  = errors.New("not support modify ambient cap of other process")
+)
 
 // NewPid initializes a new [Capabilities] object for given pid when
 // it is nonzero, or for the current process if pid is 0.

--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -334,6 +334,9 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 	}
 	if kind&BOUNDS == BOUNDS {
 		var data [2]capData
+		if c.hdr.pid != 0 {
+			return errBoundingNotMine
+		}
 		err = capget(&c.hdr, &data[0])
 		if err != nil {
 			return
@@ -364,6 +367,9 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 	}
 
 	if kind&AMBS == AMBS {
+		if c.hdr.pid != 0 {
+			return errAmbientNotMine
+		}
 		err = prctl(pr_CAP_AMBIENT, pr_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0)
 		if err != nil && err != syscall.EINVAL { //nolint:errorlint // Errors from syscall are bare.
 			// Ignore EINVAL as not supported on kernels before 4.3


### PR DESCRIPTION
There may be two ways to fix #168:
 1) Return an error when pid is not 0;
 2) Do raise and drop operation when pid is 0.

I think we should choose the second way, because besides the bug fix,
we can also have a compatibility with before.

