### PR TITLE
Makefile: fix error from test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 
 .PHONY: foreach
 foreach: ## Run $(CMD) for every package.
-	@if test -z "$(CMD)"; then \
+	@if test -z '$(CMD)'; then \
 		echo 'Usage: make foreach CMD="commands to run for every package"'; \
 		exit 1; \
 	fi


### PR DESCRIPTION
When running make test, there appears an error:

	/bin/sh: 1: test: go test -exec sudo: unexpected operator

or

	/bin/sh: line 1: test: go test -exec sudo: binary operator expected

(depending on which shell is used).

This is caused by CMD value containing extra quotes (from RUN_VIA_SUDO=-exec "sudo -n") which test sees as an extra option.

Enclose test argument in single quotes to fix the issue.