### PR TITLE
capability: Apply: deny for another process

### DIFF
--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -328,6 +328,9 @@ func (c *capsV3) Load() (err error) {
 }
 
 func (c *capsV3) Apply(kind CapType) (err error) {
+	if c.hdr.pid != 0 {
+		return errors.New("unable to modify capabilities of another process")
+	}
 	last, err := LastCap()
 	if err != nil {
 		return err


### PR DESCRIPTION
Current version of `capsV3.Apply` has a major problem: if you do something like this:
```go
	c, err := capability.NewPid(pid)
	...
	c.Set(capability.AMBIENT, capability.CAP_CHOWN)
	c.Apply(capability.AMBIENT)
```
then the ambient capability will be applied to the current process, rather than the process identified by pid. Same issue for `BOUNDS`.

For `CAPS` the situation is slightly different: `capset(2)` man page says:

> EPERM	The caller attempted to use capset() to modify the capabilities
> 	of a thread other than itself, but lacked sufficient privilege.
> 	For kernels supporting VFS capabilities, this is never permitted.

Here _kernels supporting VFS capabilities_ means most kernels >= v2.6.24, and all kernels >= v2.6.33. Since Go 1.18+ only supports Linux >= v2.6.32, this pretty much means "all kernels".

Meaning, `Apply(CAPS)` with non-zero pid will try `capset(2)` and return `EPERM`.

Let's return an error early if pid is set in Apply, and add a test case.

Fixes: #168
Closes: #171 