### PR TITLE
capability: add separate ambient and bound API

### DIFF
--- a/capability/capability.go
+++ b/capability/capability.go
@@ -163,3 +163,14 @@ func SetAmbient(raise bool, caps ...Cap) error {
 func ResetAmbient() error {
 	return resetAmbient()
 }
+
+// GetBound determines if a specific bounding capability is raised in the
+// calling thread.
+func GetBound(c Cap) (bool, error) {
+	return getBound(c)
+}
+
+// DropBound lowers the specified bounding set capability.
+func DropBound(caps ...Cap) error {
+	return dropBound(caps...)
+}

--- a/capability/capability.go
+++ b/capability/capability.go
@@ -142,3 +142,24 @@ func NewFile2(path string) (Capabilities, error) {
 func LastCap() (Cap, error) {
 	return lastCap()
 }
+
+// GetAmbient determines if a specific ambient capability is raised in the
+// calling thread.
+func GetAmbient(c Cap) (bool, error) {
+	return getAmbient(c)
+}
+
+// SetAmbient raises or lowers specified ambient capabilities for the calling
+// thread. To complete successfully, the prevailing effective capability set
+// must have a raised CAP_SETPCAP. Further, to raise a specific ambient
+// capability the inheritable and permitted sets of the calling thread must
+// already contain the specified capability.
+func SetAmbient(raise bool, caps ...Cap) error {
+	return setAmbient(raise, caps...)
+}
+
+// ResetAmbient resets all of the ambient capabilities for the calling thread
+// to their lowered value.
+func ResetAmbient() error {
+	return resetAmbient()
+}

--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -354,7 +354,7 @@ func (c *capsV3) Apply(kind CapType) error {
 					continue
 				}
 				// Ignore EINVAL since the capability may not be supported in this system.
-				err = ignoreEINVAL(prctl(syscall.PR_CAPBSET_DROP, uintptr(i), 0, 0, 0))
+				err = ignoreEINVAL(prctl(syscall.PR_CAPBSET_DROP, uintptr(i), 0))
 				if err != nil {
 					return err
 				}
@@ -371,7 +371,7 @@ func (c *capsV3) Apply(kind CapType) error {
 
 	if kind&AMBS == AMBS {
 		// Ignore EINVAL as not supported on kernels before 4.3
-		err = ignoreEINVAL(prctl(pr_CAP_AMBIENT, pr_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0))
+		err = ignoreEINVAL(prctl(pr_CAP_AMBIENT, pr_CAP_AMBIENT_CLEAR_ALL, 0))
 		if err != nil {
 			return err
 		}
@@ -380,7 +380,7 @@ func (c *capsV3) Apply(kind CapType) error {
 				continue
 			}
 			// Ignore EINVAL as not supported on kernels before 4.3
-			err = ignoreEINVAL(prctl(pr_CAP_AMBIENT, pr_CAP_AMBIENT_RAISE, uintptr(i), 0, 0))
+			err = ignoreEINVAL(prctl(pr_CAP_AMBIENT, pr_CAP_AMBIENT_RAISE, uintptr(i)))
 			if err != nil {
 				return err
 			}

--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -117,6 +117,13 @@ func newPid(pid int) (c Capabilities, retErr error) {
 	return
 }
 
+func ignoreEINVAL(err error) error {
+	if errors.Is(err, syscall.EINVAL) {
+		err = nil
+	}
+	return err
+}
+
 type capsV3 struct {
 	hdr     capHeader
 	data    [2]capData
@@ -327,7 +334,7 @@ func (c *capsV3) Load() (err error) {
 	return
 }
 
-func (c *capsV3) Apply(kind CapType) (err error) {
+func (c *capsV3) Apply(kind CapType) error {
 	if c.hdr.pid != 0 {
 		return errors.New("unable to modify capabilities of another process")
 	}
@@ -339,21 +346,17 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 		var data [2]capData
 		err = capget(&c.hdr, &data[0])
 		if err != nil {
-			return
+			return err
 		}
 		if (1<<uint(CAP_SETPCAP))&data[0].effective != 0 {
 			for i := Cap(0); i <= last; i++ {
 				if c.Get(BOUNDING, i) {
 					continue
 				}
-				err = prctl(syscall.PR_CAPBSET_DROP, uintptr(i), 0, 0, 0)
+				// Ignore EINVAL since the capability may not be supported in this system.
+				err = ignoreEINVAL(prctl(syscall.PR_CAPBSET_DROP, uintptr(i), 0, 0, 0))
 				if err != nil {
-					// Ignore EINVAL since the capability may not be supported in this system.
-					if err == syscall.EINVAL { //nolint:errorlint // Errors from syscall are bare.
-						err = nil
-						continue
-					}
-					return
+					return err
 				}
 			}
 		}
@@ -362,33 +365,29 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 	if kind&CAPS == CAPS {
 		err = capset(&c.hdr, &c.data[0])
 		if err != nil {
-			return
+			return err
 		}
 	}
 
 	if kind&AMBS == AMBS {
-		err = prctl(pr_CAP_AMBIENT, pr_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0)
-		if err != nil && err != syscall.EINVAL { //nolint:errorlint // Errors from syscall are bare.
-			// Ignore EINVAL as not supported on kernels before 4.3
-			return
+		// Ignore EINVAL as not supported on kernels before 4.3
+		err = ignoreEINVAL(prctl(pr_CAP_AMBIENT, pr_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0))
+		if err != nil {
+			return err
 		}
 		for i := Cap(0); i <= last; i++ {
 			if !c.Get(AMBIENT, i) {
 				continue
 			}
-			err = prctl(pr_CAP_AMBIENT, pr_CAP_AMBIENT_RAISE, uintptr(i), 0, 0)
+			// Ignore EINVAL as not supported on kernels before 4.3
+			err = ignoreEINVAL(prctl(pr_CAP_AMBIENT, pr_CAP_AMBIENT_RAISE, uintptr(i), 0, 0))
 			if err != nil {
-				// Ignore EINVAL as not supported on kernels before 4.3
-				if err == syscall.EINVAL { //nolint:errorlint // Errors from syscall are bare.
-					err = nil
-					continue
-				}
-				return
+				return err
 			}
 		}
 	}
 
-	return
+	return nil
 }
 
 func newFile(path string) (c Capabilities, err error) {

--- a/capability/capability_noop.go
+++ b/capability/capability_noop.go
@@ -36,3 +36,11 @@ func setAmbient(_ bool, _ ...Cap) error {
 func resetAmbient() error {
 	return errNotSup
 }
+
+func getBound(_ Cap) (bool, error) {
+	return false, errNotSup
+}
+
+func dropBound(_ ...Cap) error {
+	return errNotSup
+}

--- a/capability/capability_noop.go
+++ b/capability/capability_noop.go
@@ -24,3 +24,15 @@ func newFile(_ string) (Capabilities, error) {
 func lastCap() (Cap, error) {
 	return -1, errNotSup
 }
+
+func getAmbient(_ Cap) (bool, error) {
+	return false, errNotSup
+}
+
+func setAmbient(_ bool, _ ...Cap) error {
+	return errNotSup
+}
+
+func resetAmbient() error {
+	return errNotSup
+}

--- a/capability/capability_test.go
+++ b/capability/capability_test.go
@@ -150,6 +150,7 @@ func TestAmbientCapSet(t *testing.T) {
 }
 
 func childAmbientCapSet() {
+	runtime.LockOSThread()
 	// We can't use t.Log etc. here, yet filename and line number is nice
 	// to have. Set up and use the standard logger for this.
 	log.SetFlags(log.Lshortfile)

--- a/capability/capability_test.go
+++ b/capability/capability_test.go
@@ -42,7 +42,7 @@ func requirePCapSet(t testing.TB) {
 }
 
 // testInChild runs fn as a separate process, and returns its output.
-// This is useful for tests which manipulate capabilties, allowing to
+// This is useful for tests which manipulate capabilities, allowing to
 // preserve those of the main test process.
 //
 // The fn is a function which must end with os.Exit. In case exit code

--- a/capability/syscall_linux.go
+++ b/capability/syscall_linux.go
@@ -48,8 +48,8 @@ const (
 	pr_CAP_AMBIENT_CLEAR_ALL = uintptr(4)
 )
 
-func prctl(option int, arg2, arg3, arg4, arg5 uintptr) (err error) {
-	_, _, e1 := syscall.Syscall6(syscall.SYS_PRCTL, uintptr(option), arg2, arg3, arg4, arg5, 0)
+func prctl(option int, arg2, arg3 uintptr) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_PRCTL, uintptr(option), arg2, arg3)
 	if e1 != 0 {
 		err = e1
 	}

--- a/capability/syscall_linux.go
+++ b/capability/syscall_linux.go
@@ -56,6 +56,14 @@ func prctl(option int, arg2, arg3 uintptr) (err error) {
 	return
 }
 
+func prctlRetInt(option int, arg2, arg3 uintptr) (int, error) {
+	ret, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, uintptr(option), arg2, arg3)
+	if err != 0 {
+		return 0, err
+	}
+	return int(ret), nil
+}
+
 const (
 	vfsXattrName = "security.capability"
 

--- a/capability/syscall_linux.go
+++ b/capability/syscall_linux.go
@@ -24,7 +24,7 @@ type capData struct {
 }
 
 func capget(hdr *capHeader, data *capData) (err error) {
-	_, _, e1 := syscall.Syscall(syscall.SYS_CAPGET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	_, _, e1 := syscall.RawSyscall(syscall.SYS_CAPGET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
 	if e1 != 0 {
 		err = e1
 	}
@@ -32,7 +32,7 @@ func capget(hdr *capHeader, data *capData) (err error) {
 }
 
 func capset(hdr *capHeader, data *capData) (err error) {
-	_, _, e1 := syscall.Syscall(syscall.SYS_CAPSET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	_, _, e1 := syscall.RawSyscall(syscall.SYS_CAPSET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
 	if e1 != 0 {
 		err = e1
 	}
@@ -49,7 +49,7 @@ const (
 )
 
 func prctl(option int, arg2, arg3 uintptr) (err error) {
-	_, _, e1 := syscall.Syscall(syscall.SYS_PRCTL, uintptr(option), arg2, arg3)
+	_, _, e1 := syscall.RawSyscall(syscall.SYS_PRCTL, uintptr(option), arg2, arg3)
 	if e1 != 0 {
 		err = e1
 	}
@@ -92,7 +92,7 @@ func getVfsCap(path string, dest *vfscapData) (err error) {
 	if err != nil {
 		return
 	}
-	r0, _, e1 := syscall.Syscall6(syscall.SYS_GETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(dest)), vfscapDataSizeV2, 0, 0)
+	r0, _, e1 := syscall.RawSyscall6(syscall.SYS_GETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(dest)), vfscapDataSizeV2, 0, 0)
 	if e1 != 0 {
 		if e1 == syscall.ENODATA {
 			dest.version = 2
@@ -145,7 +145,7 @@ func setVfsCap(path string, data *vfscapData) (err error) {
 	} else {
 		return syscall.EINVAL
 	}
-	_, _, e1 := syscall.Syscall6(syscall.SYS_SETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(data)), size, 0, 0)
+	_, _, e1 := syscall.RawSyscall6(syscall.SYS_SETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(data)), size, 0, 0)
 	if e1 != 0 {
 		err = e1
 	}


### PR DESCRIPTION
The API being added is the same as in [kernel.org/pub/linux/libs/security/libcap/cap](https://pkg.go.dev/kernel.org/pub/linux/libs/security/libcap/cap)
package, although the implementation is a bit simpler (here we only set
capabilities for the calling thread).

With this, we can switch runc to moby/sys/capability.

Co-authored-by: @lifubang 
Closes: #165

