### PR TITLE
Merge functionality from `github.com/moby/moby/pkg/idtools` into `user`

### DIFF
--- a/user/idtools.go
+++ b/user/idtools.go
@@ -1,44 +1,53 @@
-package idtools
+package user
 
 import (
 	"fmt"
 	"os"
 )
 
-// IDMap contains a single entry for user namespace range remapping. An array
-// of IDMap entries represents the structure that will be provided to the Linux
-// kernel for creating a user namespace.
-type IDMap struct {
-	ContainerID int `json:"container_id"`
-	HostID      int `json:"host_id"`
-	Size        int `json:"size"`
+// MkdirOpt is a type for options to pass to Mkdir calls
+type MkdirOpt func(*mkdirOptions)
+
+type mkdirOptions struct {
+	onlyNew bool
+}
+
+// WithOnlyNew is an option for MkdirAllAndChown that will only change ownership and permissions
+// on newly created directories.  If the directory already exists, it will not be modified
+func WithOnlyNew(o *mkdirOptions) {
+	o.onlyNew = true
 }
 
 // MkdirAllAndChown creates a directory (include any along the path) and then modifies
-// ownership to the requested uid/gid.  If the directory already exists, this
-// function will still change ownership and permissions.
-func MkdirAllAndChown(path string, mode os.FileMode, owner Identity) error {
-	return mkdirAs(path, mode, owner, true, true)
+// ownership to the requested uid/gid.  By default, if the directory already exists, this
+// function will still change ownership and permissions. If WithOnlyNew is passed as an
+// option, then only the newly created directories will have ownership and permissions changed.
+func MkdirAllAndChown(path string, mode os.FileMode, uid, gid int, opts ...MkdirOpt) error {
+	var options mkdirOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return mkdirAs(path, mode, uid, gid, true, options.onlyNew)
 }
 
 // MkdirAndChown creates a directory and then modifies ownership to the requested uid/gid.
-// If the directory already exists, this function still changes ownership and permissions.
+// By default, if the directory already exists, this function still changes ownership and permissions.
+// If WithOnlyNew is passed as an option, then only the newly created directory will have ownership
+// and permissions changed.
 // Note that unlike os.Mkdir(), this function does not return IsExist error
 // in case path already exists.
-func MkdirAndChown(path string, mode os.FileMode, owner Identity) error {
-	return mkdirAs(path, mode, owner, false, true)
+func MkdirAndChown(path string, mode os.FileMode, uid, gid int, opts ...MkdirOpt) error {
+	var options mkdirOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return mkdirAs(path, mode, uid, gid, false, options.onlyNew)
 }
 
-// MkdirAllAndChownNew creates a directory (include any along the path) and then modifies
-// ownership ONLY of newly created directories to the requested uid/gid. If the
-// directories along the path exist, no change of ownership or permissions will be performed
-func MkdirAllAndChownNew(path string, mode os.FileMode, owner Identity) error {
-	return mkdirAs(path, mode, owner, true, false)
-}
-
-// GetRootUIDGID retrieves the remapped root uid/gid pair from the set of maps.
+// getRootUIDGID retrieves the remapped root uid/gid pair from the set of maps.
 // If the maps are empty, then the root uid/gid will default to "real" 0/0
-func GetRootUIDGID(uidMap, gidMap []IDMap) (int, int, error) {
+func getRootUIDGID(uidMap, gidMap []IDMap) (int, int, error) {
 	uid, err := toHost(0, uidMap)
 	if err != nil {
 		return -1, -1, err
@@ -58,12 +67,12 @@ func toContainer(hostID int, idMap []IDMap) (int, error) {
 		return hostID, nil
 	}
 	for _, m := range idMap {
-		if (hostID >= m.HostID) && (hostID <= (m.HostID + m.Size - 1)) {
-			contID := m.ContainerID + (hostID - m.HostID)
+		if (int64(hostID) >= m.ParentID) && (int64(hostID) <= (m.ParentID + m.Count - 1)) {
+			contID := int(m.ID + (int64(hostID) - m.ParentID))
 			return contID, nil
 		}
 	}
-	return -1, fmt.Errorf("Host ID %d cannot be mapped to a container ID", hostID)
+	return -1, fmt.Errorf("host ID %d cannot be mapped to a container ID", hostID)
 }
 
 // toHost takes an id mapping and a remapped ID, and translates the
@@ -74,24 +83,12 @@ func toHost(contID int, idMap []IDMap) (int, error) {
 		return contID, nil
 	}
 	for _, m := range idMap {
-		if (contID >= m.ContainerID) && (contID <= (m.ContainerID + m.Size - 1)) {
-			hostID := m.HostID + (contID - m.ContainerID)
+		if (int64(contID) >= m.ID) && (int64(contID) <= (m.ID + m.Count - 1)) {
+			hostID := int(m.ParentID + (int64(contID) - m.ID))
 			return hostID, nil
 		}
 	}
-	return -1, fmt.Errorf("Container ID %d cannot be mapped to a host ID", contID)
-}
-
-// Identity is either a UID and GID pair or a SID (but not both)
-type Identity struct {
-	UID int
-	GID int
-	SID string
-}
-
-// Chown changes the numeric uid and gid of the named file to id.UID and id.GID.
-func (id Identity) Chown(name string) error {
-	return os.Chown(name, id.UID, id.GID)
+	return -1, fmt.Errorf("container ID %d cannot be mapped to a host ID", contID)
 }
 
 // IdentityMapping contains a mappings of UIDs and GIDs.
@@ -104,46 +101,41 @@ type IdentityMapping struct {
 // RootPair returns a uid and gid pair for the root user. The error is ignored
 // because a root user always exists, and the defaults are correct when the uid
 // and gid maps are empty.
-func (i IdentityMapping) RootPair() Identity {
-	uid, gid, _ := GetRootUIDGID(i.UIDMaps, i.GIDMaps)
-	return Identity{UID: uid, GID: gid}
+func (i IdentityMapping) RootPair() (int, int) {
+	uid, gid, _ := getRootUIDGID(i.UIDMaps, i.GIDMaps)
+	return uid, gid
 }
 
 // ToHost returns the host UID and GID for the container uid, gid.
 // Remapping is only performed if the ids aren't already the remapped root ids
-func (i IdentityMapping) ToHost(pair Identity) (Identity, error) {
+func (i IdentityMapping) ToHost(uid, gid int) (int, int, error) {
 	var err error
-	target := i.RootPair()
+	ruid, rgid := i.RootPair()
 
-	if pair.UID != target.UID {
-		target.UID, err = toHost(pair.UID, i.UIDMaps)
+	if uid != ruid {
+		ruid, err = toHost(uid, i.UIDMaps)
 		if err != nil {
-			return target, err
+			return ruid, rgid, err
 		}
 	}
 
-	if pair.GID != target.GID {
-		target.GID, err = toHost(pair.GID, i.GIDMaps)
+	if gid != rgid {
+		rgid, err = toHost(gid, i.GIDMaps)
 	}
-	return target, err
+	return ruid, rgid, err
 }
 
 // ToContainer returns the container UID and GID for the host uid and gid
-func (i IdentityMapping) ToContainer(pair Identity) (int, int, error) {
-	uid, err := toContainer(pair.UID, i.UIDMaps)
+func (i IdentityMapping) ToContainer(uid, gid int) (int, int, error) {
+	ruid, err := toContainer(uid, i.UIDMaps)
 	if err != nil {
 		return -1, -1, err
 	}
-	gid, err := toContainer(pair.GID, i.GIDMaps)
-	return uid, gid, err
+	rgid, err := toContainer(gid, i.GIDMaps)
+	return ruid, rgid, err
 }
 
 // Empty returns true if there are no id mappings
 func (i IdentityMapping) Empty() bool {
 	return len(i.UIDMaps) == 0 && len(i.GIDMaps) == 0
-}
-
-// CurrentIdentity returns the identity of the current process
-func CurrentIdentity() Identity {
-	return Identity{UID: os.Getuid(), GID: os.Getegid()}
 }

--- a/user/idtools_windows.go
+++ b/user/idtools_windows.go
@@ -1,26 +1,13 @@
-package idtools
+package user
 
 import (
 	"os"
-)
-
-const (
-	// Deprecated: copy value locally
-	SeTakeOwnershipPrivilege = "SeTakeOwnershipPrivilege"
-)
-
-const (
-	// Deprecated: copy value locally
-	ContainerAdministratorSidString = "S-1-5-93-2-1"
-
-	// Deprecated: copy value locally
-	ContainerUserSidString = "S-1-5-93-2-2"
 )
 
 // This is currently a wrapper around [os.MkdirAll] since currently
 // permissions aren't set through this path, the identity isn't utilized.
 // Ownership is handled elsewhere, but in the future could be support here
 // too.
-func mkdirAs(path string, _ os.FileMode, _ Identity, _, _ bool) error {
+func mkdirAs(path string, _ os.FileMode, _, _ int, _, _ bool) error {
 	return os.MkdirAll(path, 0)
 }


### PR DESCRIPTION
Merges the idtools package functionality from github.com/moby/moby/pkg/idtools into the user package. The package was previously trimmed down and is simplified further to better fit `moby/sys`.

Now the package interface will just expand with:
- `MkdirAllAndChown` with  `WithOnlyNew` as a `MkdirOpt`
- `MkdirAndChown` also supporting the opts
- `IdentityMapping` its functions `RootPair`, `ToHost`, `ToContainer`, `Empty`

Note the `Identity` type is gone since `SID` was not used in the package or by any of the functions. It is more common to just pass along the uid and gid.