### PR TITLE
ci: add go1.24, add macOS 15, remove ubuntu 20.04 (EOL) and update golangci-lint to v2.0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.22.x, 1.23.x]
+        go-version: [1.18.x, 1.23.x, 1.24.x]
         platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-13, macos-14]
     runs-on: ${{ matrix.platform }}
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.x, 1.23.x, 1.24.x]
-        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-13, macos-14, macos-15]
+        platform: [ubuntu-22.04, ubuntu-24.04, windows-latest, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.x, 1.23.x, 1.24.x]
-        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-13, macos-14]
+        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,35 @@
+version: "2"
 linters:
   enable:
     - errorlint
-    - gofumpt
     - unconvert
     - unparam
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+  settings:
+    staticcheck:
+      # Enable all options, with some exceptions.
+      # For defaults, see https://golangci-lint.run/usage/linters/#staticcheck
+      checks:
+        - all
+        - -QF1008     # Omit embedded fields from selector expression; https://staticcheck.dev/docs/checks/#QF1008
+        - -ST1003     # Poorly chosen identifier; https://staticcheck.dev/docs/checks/#ST1003
+
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ lint:
 	$(BINDIR)/golangci-lint version
 
 $(BINDIR)/golangci-lint: $(BINDIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v1.60.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v2.0.2
 
 $(BINDIR):
 	mkdir -p $(BINDIR)


### PR DESCRIPTION
- [x] depends on https://github.com/moby/sys/pull/187
