### PR TITLE
fix linting issues for golangci-lint v2

### DIFF
--- a/capability/syscall_linux.go
+++ b/capability/syscall_linux.go
@@ -141,16 +141,17 @@ func setVfsCap(path string, data *vfscapData) (err error) {
 		return
 	}
 	var size uintptr
-	if data.version == 1 {
+	switch data.version {
+	case 1:
 		data.magic = vfsCapVer1
 		size = vfscapDataSizeV1
-	} else if data.version == 2 {
+	case 2:
 		data.magic = vfsCapVer2
 		if data.effective[0] != 0 || data.effective[1] != 0 {
 			data.magic |= vfsCapFlageffective
 		}
 		size = vfscapDataSizeV2
-	} else {
+	default:
 		return syscall.EINVAL
 	}
 	_, _, e1 := syscall.RawSyscall6(syscall.SYS_SETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(data)), size, 0, 0)

--- a/mountinfo/mounted_linux_test.go
+++ b/mountinfo/mounted_linux_test.go
@@ -279,7 +279,7 @@ func testMountedFast(t *testing.T, path string, tc *testMount, openat2Supported 
 	mounted, sure, err := MountedFast(path)
 	if err != nil {
 		// Got an error; is it expected?
-		if !(tc.isNotExist && errors.Is(err, os.ErrNotExist)) {
+		if !tc.isNotExist || !errors.Is(err, os.ErrNotExist) {
 			t.Errorf("MountedFast: unexpected error: %v", err)
 		}
 
@@ -350,7 +350,7 @@ func TestMountedBy(t *testing.T) {
 				}
 			} else {
 				// Got an error; is it expected?
-				if !(tc.isNotExist && errors.Is(err, os.ErrNotExist)) {
+				if !tc.isNotExist || !errors.Is(err, os.ErrNotExist) {
 					t.Errorf("Mounted: unexpected error: %v", err)
 				}
 				// Check false is returned in error case.

--- a/user/user.go
+++ b/user/user.go
@@ -444,7 +444,7 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 			return false
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Unable to find additional groups %v: %w", additionalGroups, err)
+			return nil, fmt.Errorf("unable to find additional groups %v: %w", additionalGroups, err)
 		}
 	}
 
@@ -468,7 +468,7 @@ func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, err
 			gid, err := strconv.ParseInt(ag, 10, 64)
 			if err != nil {
 				// Not a numeric ID either.
-				return nil, fmt.Errorf("Unable to find group %s: %w", ag, ErrNoGroupEntries)
+				return nil, fmt.Errorf("unable to find group %s: %w", ag, ErrNoGroupEntries)
 			}
 			// Ensure gid is inside gid range.
 			if gid < minID || gid > maxID {


### PR DESCRIPTION
- relates to https://github.com/moby/sys/pull/186

We could suppress this linter, as using w.File.xxx makes it slightly more explicit, but probably fine as well.

```
Error: atomicwriter/atomicwriter.go:205:11: QF1008: could remove embedded field "File" from selector (staticcheck)
	err := w.File.Sync()
	         ^
```

```
Error: mountinfo/mounted_linux_test.go:282:6: QF1001: could apply De Morgan's law (staticcheck)
		if !(tc.isNotExist && errors.Is(err, os.ErrNotExist)) {
		   ^
Error: mountinfo/mounted_linux_test.go:353:8: QF1001: could apply De Morgan's law (staticcheck)
				if !(tc.isNotExist && errors.Is(err, os.ErrNotExist)) {
				   ^
```

```
Error: capability/syscall_linux.go:144:2: QF1003: could use tagged switch on data.version (staticcheck)
	if data.version == 1 {
	^
```

```
Error: user/user.go:447:16: ST1005: error strings should not be capitalized (staticcheck)
			return nil, fmt.Errorf("Unable to find additional groups %v: %w", additionalGroups, err)
			            ^
Error: user/user.go:471:17: ST1005: error strings should not be capitalized (staticcheck)
				return nil, fmt.Errorf("Unable to find group %s: %w", ag, ErrNoGroupEntries)
				            ^
```