### PR TITLE
.golangci.yml: remove unused exceptions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,15 @@
 version: "2"
+
 linters:
   enable:
     - errorlint
     - unconvert
     - unparam
   exclusions:
-    generated: lax
+    generated: disable
     presets:
       - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
   settings:
     staticcheck:
       # Enable all options, with some exceptions.
@@ -28,8 +23,4 @@ formatters:
   enable:
     - gofumpt
   exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+    generated: disable


### PR DESCRIPTION
This is a followup to #186.

This repo:
 - does not have any paths that are excluded;
 - does not have any generated code.

 Also, neither "common-false-positives" nor "legacy" presets suppress
 any warnings, so remove those as well.