### PR TITLE
reexec: only consider basename, not path

### DIFF
--- a/reexec/reexec.go
+++ b/reexec/reexec.go
@@ -19,6 +19,9 @@ var registeredInitializers = make(map[string]func())
 // Register adds an initialization func under the specified name. It panics
 // if the given name is already registered.
 func Register(name string, initializer func()) {
+	if filepath.Base(name) != name {
+		panic(fmt.Sprintf("reexec func does not expect a path component: %q", name))
+	}
 	if _, exists := registeredInitializers[name]; exists {
 		panic(fmt.Sprintf("reexec func already registered under name %q", name))
 	}
@@ -29,7 +32,7 @@ func Register(name string, initializer func()) {
 // Init is called as the first part of the exec process and returns true if an
 // initialization function was called.
 func Init() bool {
-	if initializer, ok := registeredInitializers[os.Args[0]]; ok {
+	if initializer, ok := registeredInitializers[filepath.Base(os.Args[0])]; ok {
 		initializer()
 		return true
 	}

--- a/reexec/reexec_test.go
+++ b/reexec/reexec_test.go
@@ -1,48 +1,99 @@
 package reexec
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
-const testReExec = "test-reexec"
+const (
+	testReExec  = "test-reexec"
+	testReExec2 = "test-reexec2"
+)
 
 func init() {
 	Register(testReExec, func() {
 		panic("Return Error")
 	})
+	Register(testReExec2, func() {
+		fmt.Println("Hello " + testReExec2)
+		os.Exit(0)
+	})
 	Init()
 }
 
 func TestRegister(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			const expected = `reexec func already registered under name "test-reexec"`
-			if r != expected {
-				t.Errorf("got %q, want %q", r, expected)
-			}
-		}
-	}()
-	Register(testReExec, func() {})
+	tests := []struct {
+		doc         string
+		name        string
+		expectedErr string
+	}{
+		{
+			doc:         "duplicate name",
+			name:        testReExec,
+			expectedErr: `reexec func already registered under name "test-reexec"`,
+		},
+		{
+			doc:         "invalid name",
+			name:        filepath.Join("something", testReExec),
+			expectedErr: fmt.Sprintf("reexec func does not expect a path component: %q", filepath.Join("something", testReExec)),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Errorf("Register() did not panic")
+					return
+				}
+				if r != tc.expectedErr {
+					t.Errorf("got %q, want %q", r, tc.expectedErr)
+				}
+			}()
+			Register(tc.name, func() {})
+		})
+	}
 }
 
 func TestCommand(t *testing.T) {
-	cmd := Command(testReExec)
-	w, err := cmd.StdinPipe()
-	if err != nil {
-		t.Fatalf("Error on pipe creation: %v", err)
+	tests := []struct {
+		doc  string
+		name string
+	}{
+		{
+			doc:  "basename",
+			name: testReExec2,
+		},
+		{
+			doc:  "full path",
+			name: filepath.Join("something", testReExec2),
+		},
 	}
-	defer w.Close()
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			cmd := Command(tc.name)
+			w, err := cmd.StdinPipe()
+			if err != nil {
+				t.Fatalf("Error on pipe creation: %v", err)
+			}
+			defer func() { _ = w.Close() }()
 
-	err = cmd.Start()
-	if err != nil {
-		t.Fatalf("Error on re-exec cmd: %v", err)
-	}
-	err = cmd.Wait()
-	const expected = "exit status 2"
-	if err == nil || err.Error() != expected {
-		t.Fatalf("got %v, want %v", err, expected)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Errorf("Error on re-exec cmd: %v, out: %v", err, string(out))
+			}
+
+			const expected = "Hello " + testReExec2
+			actual := strings.TrimSpace(string(out))
+			if actual != expected {
+				t.Errorf("got %v, want %v", actual, expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The intent of reexec is to provide functionality similar to multi-call binaries (like "busybox"). However, currently, re-exec also includes path information when matching. This does not match behavior like busybox;

    date --help 2>&1 | grep Usage
    Usage: date [OPTIONS] [+FMT] [[-s] TIME]

    mkdir foo
    ln -s /bin/busybox ./foo/date
    ./foo/date --help 2>&1 | grep Usage

This patch changes the behavior to only consider the basename, and disregard path.

With this patch applied:

Basic example:

```go
package main

import (
	"fmt"
	"os"

	"github.com/moby/sys/reexec"
)

func init() {
	reexec.Register("hello-foo", func() {
		fmt.Println("Hello Foo")
		os.Exit(0)
	})
	reexec.Register("hello-bar", func() {
		fmt.Println("Hello Bar")
		os.Exit(0)
	})

	reexec.Init()
}

func main() {
	fmt.Println("Hello Main")
}
```

executing the binary, including path (`./`) now selects the correct
function to execute.

```bash
go build -o ./example
ln -s ./example hello-foo
ln -s ./example hello-bar
ln -s ./example hello-baz

./example
# Hello Main

./hello-foo
# Hello Foo

./hello-bar
# Hello Bar

./hello-baz
# Hello Main
```

Before this patch, all of the above would fall through to use `main` instead;

```bash
./example
# Hello Main

./hello-foo
# Hello Main

./hello-bar
# Hello Main

./hello-baz
# Hello Main
```