### PR TITLE
reexec: add "CommandContext"

### DIFF
--- a/reexec/reexec.go
+++ b/reexec/reexec.go
@@ -7,6 +7,7 @@
 package reexec
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,6 +51,20 @@ func Init() bool {
 // not terminated prematurely. See https://go.dev/issue/27505 for more details.
 func Command(args ...string) *exec.Cmd {
 	return command(args...)
+}
+
+// CommandContext is like [Command] but includes a context. It uses
+// [exec.CommandContext] under the hood.
+//
+// The provided context is used to interrupt the process
+// (by calling cmd.Cancel or [os.Process.Kill])
+// if the context becomes done before the command completes on its own.
+//
+// CommandContext sets the command's Cancel function to invoke the Kill method
+// on its Process, and leaves its WaitDelay unset. The caller may change the
+// cancellation behavior by modifying those fields before starting the command.
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	return commandContext(ctx, args...)
 }
 
 // Self returns the path to the current process's binary.

--- a/reexec/reexec_linux.go
+++ b/reexec/reexec_linux.go
@@ -1,6 +1,7 @@
 package reexec
 
 import (
+	"context"
 	"os/exec"
 	"syscall"
 )
@@ -10,6 +11,18 @@ func command(args ...string) *exec.Cmd {
 	// constructing the cmd, we remove "Self()" from cmd.Args, which
 	// is prepended by exec.Command.
 	cmd := exec.Command(Self(), args...)
+	cmd.Args = cmd.Args[1:]
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+	return cmd
+}
+
+func commandContext(ctx context.Context, args ...string) *exec.Cmd {
+	// We try to stay close to exec.Command's behavior, but after
+	// constructing the cmd, we remove "Self()" from cmd.Args, which
+	// is prepended by exec.Command.
+	cmd := exec.CommandContext(ctx, Self(), args...)
 	cmd.Args = cmd.Args[1:]
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGTERM,

--- a/reexec/reexec_other.go
+++ b/reexec/reexec_other.go
@@ -3,6 +3,7 @@
 package reexec
 
 import (
+	"context"
 	"os/exec"
 )
 
@@ -11,6 +12,15 @@ func command(args ...string) *exec.Cmd {
 	// constructing the cmd, we remove "Self()" from cmd.Args, which
 	// is prepended by exec.Command.
 	cmd := exec.Command(Self(), args...)
+	cmd.Args = cmd.Args[1:]
+	return cmd
+}
+
+func commandContext(ctx context.Context, args ...string) *exec.Cmd {
+	// We try to stay close to exec.Command's behavior, but after
+	// constructing the cmd, we remove "Self()" from cmd.Args, which
+	// is prepended by exec.Command.
+	cmd := exec.CommandContext(ctx, Self(), args...)
 	cmd.Args = cmd.Args[1:]
 	return cmd
 }


### PR DESCRIPTION
- follow-up to / stacked on https://github.com/moby/sys/pull/191


Adds a CommandContext command, to provide the equivalent of exec.CommandContext.