### PR TITLE
reexec: test cmd.Cancel, bump minimum go version to go1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,9 @@ jobs:
       if: ${{ matrix.go-version == '1.18.x' }}
       run: |
         # This corresponds with the list in Makefile:1, but omits the "userns"
-        # and "capability" modules, which require go1.21 as minimum.
-        echo 'PACKAGES=atomicwriter mountinfo mount reexec sequential signal symlink user' >> $GITHUB_ENV
+        # and "capability" modules, which require go1.21 as minimum, and "reexec",
+        # which requires go1.20 in tests.
+        echo 'PACKAGES=atomicwriter mountinfo mount sequential signal symlink user' >> $GITHUB_ENV
     - name: go mod tidy
       run: |
         make foreach CMD="go mod tidy"

--- a/reexec/go.mod
+++ b/reexec/go.mod
@@ -1,3 +1,3 @@
 module github.com/moby/sys/reexec
 
-go 1.18
+go 1.20


### PR DESCRIPTION
- stacked on https://github.com/moby/sys/pull/193

---

### reexec: test cmd.Cancel, bump minimum go version to go1.20

This requires go1.20 or up; https://go-review.googlesource.com/23300
