### PR TITLE
ci: don't install private golangci-lint; bump to v2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,13 @@ jobs:
         # the cache key, and specifying multiple go.sums is not trivial
         # (see https://github.com/moby/sys/pull/160 for details).
         cache: false
+    - name: Install golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: v2.4
+        # We don't need to run golangci-lint here yet, but
+        # there's no way to avoid it, so run it on one module.
+        working-directory: ./mountinfo
     - name: Set PACKAGES env
       if: ${{ matrix.go-version == '1.18.x' }}
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/_build/
 /mount/go-local.*
 coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 PACKAGES ?= atomicwriter capability mountinfo mount reexec sequential signal symlink user userns
-BINDIR ?= _build/bin
 CROSS ?= linux/arm linux/arm64 linux/ppc64le linux/s390x \
 	freebsd/amd64 openbsd/amd64 darwin/amd64 darwin/arm64 windows/amd64
 SUDO ?= sudo -n
@@ -47,18 +46,14 @@ test-local:
 	cd atomicwriter && go mod tidy $(MOD) && go test $(MOD) $(RUN_VIA_SUDO) -v .
 	$(RM) atomicwriter/go-local.*
 
+.PHONY: golangci-lint-version
+golangci-lint-version:
+	golangci-lint version
+
 .PHONY: lint
-lint: $(BINDIR)/golangci-lint
-lint: CMD=go mod download; ../$(BINDIR)/golangci-lint run
+lint: golangci-lint-version
+lint: CMD=go mod download; golangci-lint run
 lint: foreach
-lint:
-	$(BINDIR)/golangci-lint version
-
-$(BINDIR)/golangci-lint: $(BINDIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINDIR) v2.0.2
-
-$(BINDIR):
-	mkdir -p $(BINDIR)
 
 .PHONY: cross
 cross:


### PR DESCRIPTION
First, let's not install golangci-lint from Makefile, instead relying on whatever version a developer already has installed and available.

Second, we still need golangci-lint in GHA CI. For that, let's use golangci-lint-action. Unfortunately, there's no way to NOT run it from the action, or run it on multiple directories (see [1]), so run it on a single module.

This is better for CI because we use all the good bits from the golangci-lint-action (caching and annotations).

While at it, bump golangci-lint from v2.0.3 to v2.4.x.

[1]: https://github.com/golangci/golangci-lint-action/issues/1226