### PR TITLE
CI: add go 1.25, drop 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.23.x, 1.24.x]
+        go-version: [1.18.x, 1.24.x, 1.25.x]
         platform: [ubuntu-22.04, ubuntu-24.04, windows-latest, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.platform }}
     defaults:


### PR DESCRIPTION
Since Go 1.25 is out, 1.23 is no longer officially supported.