### PR TITLE
gha: skip modules on unsupported Go versions, test against 1.18.x, oldstable, stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,21 @@ jobs:
     - name: Set PACKAGES env
       if: ${{ matrix.go-version == '1.18.x' }}
       run: |
-        # This corresponds with the list in Makefile:1, but omits the "userns"
-        # and "capability" modules, which require go1.21 as minimum, and "reexec",
-        # which requires go1.20 in tests.
-        echo 'PACKAGES=atomicwriter mountinfo mount sequential signal symlink user' >> $GITHUB_ENV
+        # Check if the module supports this version of Go.
+        go_version="$(go env GOVERSION)"
+        go_version="${go_version#go}"
+        
+        packages=""
+        for p in */; do
+          [ -f "$p/go.mod" ] || continue
+          if ! (cd "$p" && go list -m -f "{{if gt .GoVersion \"$go_version\"}}ko{{end}}" | grep -q ko); then
+            packages+="${p%/} "
+          else
+            echo "::notice::SKIP: github.com/moby/sys/${p%/} requires a more recent version of Go"
+          fi
+        done
+        
+        echo "PACKAGES=${packages}" >> "$GITHUB_ENV"
     - name: go mod tidy
       run: |
         make foreach CMD="go mod tidy"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.23.x, 1.24.x]
+        go-version: [1.18.x, oldstable, stable]
         platform: [ubuntu-22.04, ubuntu-24.04, windows-latest, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.platform }}
     defaults:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES ?= atomicwriter capability mountinfo mount reexec sequential signal symlink user userns # IMPORTANT: when updating this list, also update the conditional one in .github/workflows/test.yml
+PACKAGES ?= atomicwriter capability mountinfo mount reexec sequential signal symlink user userns
 BINDIR ?= _build/bin
 CROSS ?= linux/arm linux/arm64 linux/ppc64le linux/s390x \
 	freebsd/amd64 openbsd/amd64 darwin/amd64 darwin/arm64 windows/amd64


### PR DESCRIPTION
- supersedes, closes https://github.com/moby/sys/pull/196

Some modules require a more recent version of Go and must be skipped in tests. Previously we manually kept a list, but we can detect the version of Go that's required from the go.mod.
