### PR TITLE
Add uname package

### DIFF
--- a/uname/LICENSE.BSD
+++ b/uname/LICENSE.BSD
@@ -1,0 +1,27 @@
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/uname/go.mod
+++ b/uname/go.mod
@@ -1,0 +1,3 @@
+module github.com/moby/sys/uname
+
+go 1.18

--- a/uname/kernel_version.go
+++ b/uname/kernel_version.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025 The moby/sys Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package uname provides a simple way to check the kernel version.
+// Currently it only supports Linux.
+package uname
+
+// KernelVersion returns major and minor kernel version numbers
+// parsed from the [syscall.Uname] Release field, or (0, 0) if
+// the version can't be obtained or parsed.
+func KernelVersion() (major, minor int) {
+	return kernelVersion()
+}

--- a/uname/kernel_version_ge.go
+++ b/uname/kernel_version_ge.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 The Go Authors
+// SPDX-FileCopyrightText: 2025 The moby/sys Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.BSD file.
+
+package uname
+
+// KernelVersionGE checks if the running kernel version
+// is greater than or equal to the provided version.
+func KernelVersionGE(x, y int) bool {
+	xx, yy := KernelVersion()
+
+	return xx > x || (xx == x && yy >= y)
+}

--- a/uname/kernel_version_ge_test.go
+++ b/uname/kernel_version_ge_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025 The Go Authors
+// SPDX-FileCopyrightText: 2025 The moby/sys Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.BSD file.
+
+package uname_test
+
+import (
+	"testing"
+
+	"github.com/moby/sys/uname"
+)
+
+func TestKernelVersionGE(t *testing.T) {
+	major, minor := uname.KernelVersion()
+	t.Logf("Running on kernel %d.%d", major, minor)
+
+	tests := []struct {
+		name string
+		x, y int
+		want bool
+	}{
+		{
+			name: "current version equals itself",
+			x:    major,
+			y:    minor,
+			want: true,
+		},
+		{
+			name: "older major version",
+			x:    major - 1,
+			y:    0,
+			want: true,
+		},
+		{
+			name: "same major, older minor version",
+			x:    major,
+			y:    minor - 1,
+			want: true,
+		},
+		{
+			name: "newer major version",
+			x:    major + 1,
+			y:    0,
+			want: false,
+		},
+		{
+			name: "same major, newer minor version",
+			x:    major,
+			y:    minor + 1,
+			want: false,
+		},
+		{
+			name: "min version (0.0)",
+			x:    0,
+			y:    0,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := uname.KernelVersionGE(tt.x, tt.y)
+			if got != tt.want {
+				t.Errorf("KernelVersionGE(%d, %d): got %v, want %v", tt.x, tt.y, got, tt.want)
+			}
+		})
+	}
+}

--- a/uname/kernel_version_linux.go
+++ b/uname/kernel_version_linux.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2022 The Go Authors
+// SPDX-FileCopyrightText: 2025 The moby/sys Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.BSD file.
+
+package uname
+
+import (
+	"syscall"
+)
+
+func kernelVersion() (major, minor int) {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return
+	}
+
+	var (
+		values    [2]int
+		value, vi int
+	)
+	for _, c := range uname.Release {
+		if '0' <= c && c <= '9' {
+			value = (value * 10) + int(c-'0')
+		} else {
+			// Note that we're assuming N.N.N here.
+			// If we see anything else, we are likely to mis-parse it.
+			values[vi] = value
+			vi++
+			if vi >= len(values) {
+				break
+			}
+			value = 0
+		}
+	}
+
+	return values[0], values[1]
+}

--- a/uname/kernel_version_other.go
+++ b/uname/kernel_version_other.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2022 The Go Authors
+// SPDX-FileCopyrightText: 2025 The moby/sys Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.BSD file.
+
+//go:build !linux
+
+package uname
+
+func kernelVersion() (major int, minor int) {
+	return 0, 0
+}

--- a/uname/kernel_version_test.go
+++ b/uname/kernel_version_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 The moby/sys Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package uname_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/moby/sys/uname"
+)
+
+func TestKernelVersion(t *testing.T) {
+	x, y := uname.KernelVersion()
+	t.Logf("KernelVersion: %d.%d (GOOS: %s)", x, y, runtime.GOOS)
+	switch runtime.GOOS {
+	case "linux":
+		// Go requires Linux >= 2.x.
+		if x < 2 {
+			t.Errorf("want major >= 2, got %d", x)
+		}
+		// Sanity check.
+		if y < 0 {
+			t.Errorf("want minor >= 0, got %d", y)
+		}
+	default:
+		if x != 0 || y != 0 {
+			t.Fatalf("want 0.0, got %d.%d", x, y)
+		}
+	}
+}


### PR DESCRIPTION
This is a tiny package to check the Linux kernel version. It is taken
from the golang sources (src/internal/syscall/unix), with the irrelevant
parts, including FreeBSD and Solaris implementations, removed.
    
The code is covered by the "BSD 3-clause" license, which is compatible
with Apache license.
    
The history of the code before the fork can be seen here (oldest first):
  - https://go-review.googlesource.com/c/go/+/424896
  - https://go-review.googlesource.com/c/go/+/427675
  - https://go-review.googlesource.com/c/go/+/427676

On top of that, this PR includes:
 - a simple test for `KernelVersion`;
 - `KernelVersionGE` function (same as in
    https://go-review.googlesource.com/c/go/+/700796).
    
This is aimed to replace the relevant containerd package
(github.com/containerd/containerd/pkg/kernelversion) and its forks.
The difference is smaller code and simpler API.

Usage example:
```go
import "github.com/moby/sys/uname"

// ...

if !uname.KernelVersionGE(4,18) {
   return errors.New("Linux kernel 4.18 or greater is required")
}
```
