### PR TITLE
ci: test against per-module minimum go version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,33 @@ on: [push, pull_request]
 
 jobs:
   test:
+    name: ${{ matrix.module }} / ${{ matrix.platform }} / ${{ matrix.go-version || 'minimum' }}
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.18.x, oldstable, stable]
+        module:
+          - atomicwriter
+          - capability
+          - mount
+          - mountinfo
+          - reexec
+          - sequential
+          - signal
+          - symlink
+          - user
+          - userns
+        go-version:
+          - "" # do not specify go-version to fall back on go-version-file (use go.mod); see https://github.com/actions/setup-go/issues/450#issuecomment-3620402646
+          - oldstable
+          - stable
         platform: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-15, macos-26]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 10 # guardrails timeout for the whole job
+
+    env:
+      GOTOOLCHAIN: local
+      PACKAGES: ${{ matrix.module }}
+
     defaults:
       run:
         shell: bash
@@ -33,6 +54,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
+        go-version-file: ./${{ matrix.module }}/go.mod # used when go-version is not specified.
         # Disable caching as we don't have top-level go.sum needed for
         # the cache key, and specifying multiple go.sums is not trivial
         # (see https://github.com/moby/sys/pull/160 for details).
@@ -43,25 +65,8 @@ jobs:
         version: v2.10
         # We don't need to run golangci-lint here yet, but
         # there's no way to avoid it, so run it on one module.
-        working-directory: ./mountinfo
-    - name: Set PACKAGES env
-      if: ${{ matrix.go-version == '1.18.x' }}
-      run: |
-        # Check if the module supports this version of Go.
-        go_version="$(go env GOVERSION)"
-        go_version="${go_version#go}"
-        
-        packages=""
-        for p in */; do
-          [ -f "$p/go.mod" ] || continue
-          if ! (cd "$p" && go list -m -f "{{if gt .GoVersion \"$go_version\"}}ko{{end}}" | grep -q ko); then
-            packages+="${p%/} "
-          else
-            echo "::notice::SKIP: github.com/moby/sys/${p%/} requires a more recent version of Go"
-          fi
-        done
-        
-        echo "PACKAGES=${packages}" >> "$GITHUB_ENV"
+        working-directory: ./${{ matrix.module }}
+
     - name: go mod tidy
       run: |
         make foreach CMD="go mod tidy"


### PR DESCRIPTION
Go-setup action allow specifying both a "go-version" and "go-version-file", in which case it falls back to the version-file if "go-version" is empty.

This allows us to iterate over all modules, and run CI on the oldest supported Go version for each (in addition to "oldstable" and "stable").