### PR TITLE
gha: fix go version check for changes in go.mod go directive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Default
-* text=auto
+* text=auto eol=lf
 
 # Go files should always have UNIX-style line endings
 # (see e.g. https://github.com/golang/go/issues/16355)
 *.go	text eol=lf
+*.md	text eol=lf
+go.mod	text eol=lf
+go.sum	text eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,13 +54,20 @@ jobs:
         packages=""
         for p in */; do
           [ -f "$p/go.mod" ] || continue
-          if ! (cd "$p" && go list -m -f "{{if gt .GoVersion \"$go_version\"}}ko{{end}}" | grep -q ko); then
-            packages+="${p%/} "
-          else
+          if (cd "$p" && go list -m -f "{{if gt .GoVersion \"$go_version\"}}ko{{end}}" 2>/dev/null | grep -q ko); then
             echo "::notice::SKIP: github.com/moby/sys/${p%/} requires a more recent version of Go"
+          elif ! (cd "$p" && go list -m >/dev/null 2>&1); then
+            echo "::notice::SKIP: github.com/moby/sys/${p%/} is not supported by Go ${go_version}"
+          else
+            packages+="${p%/} "
           fi
         done
         
+        if [ -z "$packages" ]; then
+          echo "::error::No packages are supported by Go ${go_version}"
+          exit 1
+        fi
+
         echo "PACKAGES=${packages}" >> "$GITHUB_ENV"
     - name: go mod tidy
       run: |

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test: foreach
 .PHONY: test-local
 test-local: MOD = -modfile=go-local.mod
 test-local:
-	@if printf '%s\n' $(PACKAGES) | grep -qx mount && \
+	@set -eu; if printf '%s\n' $(PACKAGES) | grep -qx mount && \
 		printf '%s\n' $(PACKAGES) | grep -qx mountinfo; then \
 		echo 'replace github.com/moby/sys/mountinfo => ../mountinfo' | cat mount/go.mod - > mount/go-local.mod; \
 		cd mount && go mod tidy $(MOD) && go test $(MOD) $(RUN_VIA_SUDO) -v .; \
@@ -45,7 +45,7 @@ test-local:
 	else \
 		echo "SKIP: mount local dependency test requires mount and mountinfo"; \
 	fi
-	@if printf '%s\n' $(PACKAGES) | grep -qx atomicwriter && \
+	@set -eu; if printf '%s\n' $(PACKAGES) | grep -qx atomicwriter && \
 		printf '%s\n' $(PACKAGES) | grep -qx sequential; then \
 		echo 'replace github.com/moby/sys/sequential => ../sequential' | cat atomicwriter/go.mod - > atomicwriter/go-local.mod; \
 		cd atomicwriter && go mod tidy $(MOD) && go test $(MOD) $(RUN_VIA_SUDO) -v .; \

--- a/Makefile
+++ b/Makefile
@@ -37,14 +37,22 @@ test: foreach
 .PHONY: test-local
 test-local: MOD = -modfile=go-local.mod
 test-local:
-	echo 'replace github.com/moby/sys/mountinfo => ../mountinfo' | cat mount/go.mod - > mount/go-local.mod
-	# Run go mod tidy to make sure mountinfo dependency versions are met.
-	cd mount && go mod tidy $(MOD) && go test $(MOD) $(RUN_VIA_SUDO) -v .
-	$(RM) mount/go-local.*
-	echo 'replace github.com/moby/sys/sequential => ../sequential' | cat atomicwriter/go.mod - > atomicwriter/go-local.mod
-	# Run go mod tidy to make sure sequential dependency versions are met.
-	cd atomicwriter && go mod tidy $(MOD) && go test $(MOD) $(RUN_VIA_SUDO) -v .
-	$(RM) atomicwriter/go-local.*
+	@if printf '%s\n' $(PACKAGES) | grep -qx mount && \
+		printf '%s\n' $(PACKAGES) | grep -qx mountinfo; then \
+		echo 'replace github.com/moby/sys/mountinfo => ../mountinfo' | cat mount/go.mod - > mount/go-local.mod; \
+		cd mount && go mod tidy $(MOD) && go test $(MOD) $(RUN_VIA_SUDO) -v .; \
+		$(RM) mount/go-local.*; \
+	else \
+		echo "SKIP: mount local dependency test requires mount and mountinfo"; \
+	fi
+	@if printf '%s\n' $(PACKAGES) | grep -qx atomicwriter && \
+		printf '%s\n' $(PACKAGES) | grep -qx sequential; then \
+		echo 'replace github.com/moby/sys/sequential => ../sequential' | cat atomicwriter/go.mod - > atomicwriter/go-local.mod; \
+		cd atomicwriter && go mod tidy $(MOD) && go test $(MOD) $(RUN_VIA_SUDO) -v .; \
+		$(RM) atomicwriter/go-local.*; \
+	else \
+		echo "SKIP: atomicwriter local dependency test requires atomicwriter and sequential"; \
+	fi
 
 .PHONY: golangci-lint-version
 golangci-lint-version:


### PR DESCRIPTION
- relates to https://github.com/moby/sys/pull/216


### gha: fix go version check for changes in go.mod go directive

The go directive now uses a full version, which can't be parsed by
older versions of go;

    invalid go version '1.24.0': must match format 1.23

### Makefile: test-local: skip if go version is not supported

While some modules support go1.18, they may not be when updating the
dependency to later versions, which can happen when using the "local"
versions.

Check if both packages support the Go version used for the test, and
skip kip testing those packages if the Go version is not supported after
updating to the latest version of the dependency.

    echo 'replace github.com/moby/sys/sequential => ../sequential' | cat atomicwriter/go.mod - > atomicwriter/go-local.mod
    # Run go mod tidy to make sure sequential dependency versions are met.
    cd atomicwriter && go mod tidy -modfile=go-local.mod && go test -modfile=go-local.mod  -v .
    go: downloading golang.org/x/sys v0.37.0
    # golang.org/x/sys/windows
    Error: C:\Users\runneradmin\go\pkg\mod\golang.org\x\sys@v0.37.0\windows\security_windows.go:1318:39: undefined: unsafe.SliceData
    Error: C:\Users\runneradmin\go\pkg\mod\golang.org\x\sys@v0.37.0\windows\security_windows.go:1321:39: undefined: unsafe.SliceData
    Error: C:\Users\runneradmin\go\pkg\mod\golang.org\x\sys@v0.37.0\windows\security_windows.go:1324:40: undefined: unsafe.SliceData
    Error: C:\Users\runneradmin\go\pkg\mod\golang.org\x\sys@v0.37.0\windows\security_windows.go:1327:40: undefined: unsafe.SliceData
    note: module requires Go 1.24
    FAIL	github.com/moby/sys/atomicwriter [build failed]
    FAIL
    make: *** [Makefile:46: test-local] Error 2
    Error: Process completed with exit code 2.

### update gitattributes for line-endings

Reduce some noise in CI on Windows:

    warning: in the working copy of 'atomicwriter/go.mod', LF will be replaced by CRLF the next time Git touches it
    warning: in the working copy of 'mount/go.mod', LF will be replaced by CRLF the next time Git touches it
    warning: in the working copy of 'mountinfo/go.mod', LF will be replaced by CRLF the next time Git touches it

