### PR TITLE
user: fix TestParseGroupFileCapsReads, skip TestParseGroupFilterDevZero on windows

### DIFF
--- a/user/user_test.go
+++ b/user/user_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -181,6 +182,9 @@ func TestTestParseGroupFileCapsReadsonRegularFile(t *testing.T) {
 }
 
 func TestParseGroupFilterDevZero(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("depends on /dev/zero")
+	}
 	dn, err := os.Open("/dev/zero")
 	if err != nil {
 		t.Fatal(err)

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -133,7 +132,13 @@ func TestParseGroupFileCapsReads(t *testing.T) {
 			tmpDir := t.TempDir()
 			fileName := filepath.Join(tmpDir, "etc-group")
 
-			data := append(bytes.Repeat([]byte{0}, tc.padBytes), beyond...)
+			pattern := []byte("# padding\n")
+			pad := bytes.Repeat(pattern, (tc.padBytes+len(pattern)-1)/len(pattern))[:tc.padBytes]
+			if len(pad) > 0 && pad[len(pad)-1] != '\n' {
+				pad[len(pad)-1] = '\n'
+			}
+
+			data := append(pad, beyond...)
 			err := os.WriteFile(fileName, data, 0o644)
 			if err != nil {
 				t.Fatal(err)
@@ -155,7 +160,7 @@ func TestParseGroupFileCapsReads(t *testing.T) {
 			for _, g := range gids {
 				haveGids = append(haveGids, g.Gid)
 			}
-			if !slices.Equal(haveGids, tc.expGIDs) {
+			if !reflect.DeepEqual(haveGids, tc.expGIDs) {
 				t.Fatalf("unexpected gids: got %v, want %v", gids, tc.expGIDs)
 			}
 		})


### PR DESCRIPTION
This test broke after 2c56c3d5d089bfa66d01b6c0bb69428e9d5d18c5 added additional per-line constraints, which would be hit before the file- size limit was reached.