### PR TITLE
user: GetExecUser: use strings.Cut to split user:group

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -305,9 +305,8 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 		user.Sgids = []int{}
 	}
 
-	// Allow for userArg to have either "user" syntax, or optionally "user:group" syntax
-	var userArg, groupArg string
-	parseLine([]byte(userSpec), &userArg, &groupArg)
+	// Allow for userSpec to have either "user", or optionally "user:group" syntax.
+	userArg, groupArg, _ := strings.Cut(userSpec, ":")
 
 	// Convert userArg and groupArg to be numeric, so we don't have to execute
 	// Atoi *twice* for each iteration over lines.


### PR DESCRIPTION
This was using parseParts to split the colon-separated strings, but this required both converting to a byte-slice, and an intermediate slice (split by colon).

Use strings.Cut, which makes it more transparent what's done and to reduce allocations.