### PR TITLE
user: GetExecUser: always clone default Sgids

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -296,13 +296,8 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 	user := &ExecUser{
 		Uid:   defaults.Uid,
 		Gid:   defaults.Gid,
-		Sgids: defaults.Sgids,
+		Sgids: append([]int{}, defaults.Sgids...), // Sgids slice *cannot* be nil.
 		Home:  defaults.Home,
-	}
-
-	// Sgids slice *cannot* be nil.
-	if user.Sgids == nil {
-		user.Sgids = []int{}
 	}
 
 	// Allow for userSpec to have either "user", or optionally "user:group" syntax.


### PR DESCRIPTION
Clone the default Sgids slice instead of sharing it to prevent accidentally mutating, and simplify the initialization by creating a non-nil copy directly.