### PR TITLE
user: fix swapped file references in error godoc

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -17,9 +17,9 @@ const (
 )
 
 var (
-	// ErrNoPasswdEntries is returned if no matching entries were found in /etc/group.
+	// ErrNoPasswdEntries is returned if no matching entries were found in /etc/passwd.
 	ErrNoPasswdEntries = errors.New("no matching entries in passwd file")
-	// ErrNoGroupEntries is returned if no matching entries were found in /etc/passwd.
+	// ErrNoGroupEntries is returned if no matching entries were found in /etc/group.
 	ErrNoGroupEntries = errors.New("no matching entries in group file")
 	// ErrRange is returned if a UID or GID is outside of the valid range.
 	ErrRange = fmt.Errorf("uids and gids must be in range %d-%d", minID, maxID)


### PR DESCRIPTION
The doc comments on ErrNoPasswdEntries and ErrNoGroupEntries are swapped. ErrNoPasswdEntries ("no matching entries in passwd file", returned from LookupUser/LookupUid and GetExecUser's user lookup) is documented as /etc/group, and ErrNoGroupEntries ("no matching entries in group file", returned from LookupGroup/LookupGid and GetExecUser's group lookup) is documented as /etc/passwd. Each comment names the other file.

The variable name, error message, and every usage agree; only the comment is wrong, and since these are exported errors the incorrect text shows up in godoc. This swaps the two references so each comment matches its variable.
