### PR TITLE
parseNumeric: require non-empty values

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -243,9 +243,6 @@ func GetExecUserPath(userSpec string, defaults *ExecUser, passwdPath, groupPath 
 //
 // See https://github.com/containerd/containerd/commit/de1341c201ffb0effebbf51d00376181968c8779
 func parseNumeric(val string) (int, bool, error) {
-	if val == "" {
-		return 0, false, nil
-	}
 	id, err := strconv.Atoi(val)
 	if err != nil {
 		if errors.Is(err, strconv.ErrSyntax) {


### PR DESCRIPTION
follow-up to 841c83ee0d9315e5f4379361afe493c7e020c8c8 (https://github.com/moby/sys/pull/231) and 743614ec8aec7c62839dd3acf615da4e4de560d6 (https://github.com/moby/sys/pull/232).

Now that optional user-values are handled through parseGroupArg and parseUserArg (both of which gracefully handle empty values), we can make parseNumeric strict, and produce an error when trying to parse an empty string.
