### PR TITLE
atomicwrite: update github.com/moby/sys/sequential v0.7.0

### DIFF
--- a/atomicwriter/go.mod
+++ b/atomicwriter/go.mod
@@ -1,7 +1,7 @@
 module github.com/moby/sys/atomicwriter
 
-go 1.18
+go 1.24.0
 
-require github.com/moby/sys/sequential v0.6.0
+require github.com/moby/sys/sequential v0.7.0
 
-require golang.org/x/sys v0.1.0 // indirect
+require golang.org/x/sys v0.37.0 // indirect

--- a/atomicwriter/go.sum
+++ b/atomicwriter/go.sum
@@ -1,4 +1,4 @@
-github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
-github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/moby/sys/sequential v0.7.0 h1:ASQNGNROJSuOO6LL6bPHbKvuZu6NU8P4ldPWk31zj/8=
+github.com/moby/sys/sequential v0.7.0/go.mod h1:NfSTAp6V3fw4tmkD62PEcOKeZKquXT8VKCkf7aVR79o=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
- update minimum go version to 1.24
- use os.OpenFile with O_FILE_FLAG_SEQUENTIAL_SCAN on Go 1.26+