### PR TITLE
CI: bump golangci-lint to v2.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
         # (see https://github.com/moby/sys/pull/160 for details).
         cache: false
     - name: Install golangci-lint
-      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
-        version: v2.10
+        version: v2.13
         # We don't need to run golangci-lint here yet, but
         # there's no way to avoid it, so run it on one module.
         working-directory: ./mountinfo


### PR DESCRIPTION
Bumps golangci-lint from v2.10 to v2.13, and golangci-lint-action from v9.2.0 to v9.3.0.

**Why:** the old linter fails with newer Go. golangci-lint v2.10 is built with Go 1.26, and its bundled `go/types` can not read export data produced by Go 1.27, so every package fails to typecheck:

```
mountinfo/mounted_linux.go:4:2: could not import os (.../os/dir.go:8:2: could not import
internal/bytealg (.../internal/bytealg/bytealg.go:8:2: could not import internal/cpu (-:
could not load export data: internal error in importing "internal/cpu" (cannot decode
"internal/cpu", export data version 4 is greater than maximum supported version 2);
please report an issue))) (typecheck)
```

Since the CI matrix includes `stable` (now Go 1.27), this affects the lint job.

**Verified:** ran the official v2.13.2 release binary (built with Go 1.27.0) against Go 1.27.0 over all modules — 0 issues everywhere, and `golangci-lint config verify` is happy with the existing `.golangci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)