### PR TITLE
CI: bump actions, add ubuntu 26.04, dependabot, zizmor, actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# ubuntu-26.04 is still in public preview, and actionlint does not know
+# about it yet; remove this once it does.
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,26 @@
+name: Actionlint
+
+# Default to 'contents: read', which grants actions to read commits.
+#
+# If any permission is set, any permission not included in the list is
+# implicitly set to "none".
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on: [push, pull_request]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10 # guardrails timeout for the whole job
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: devops-actions/actionlint@ec02b36684b2f574f1d219ad0a43b082e46bf3e4 # v0.1.13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,9 @@ jobs:
         shell: bash
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ matrix.go-version }}
         # Disable caching as we don't have top-level go.sum needed for
@@ -87,7 +87,7 @@ jobs:
         uname -a
         make test
     - name: Send to Codecov
-      uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}  # used to upload coverage reports: https://github.com/moby/buildkit/pull/4660#issue-2142122533
 
@@ -95,6 +95,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10 # guardrails timeout for the whole job
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - run: pip install --break-system-packages codespell==v2.3.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - run: pip install --break-system-packages codespell==v2.4.3
     - run: codespell

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
@@ -96,5 +98,7 @@ jobs:
     timeout-minutes: 10 # guardrails timeout for the whole job
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - run: pip install --break-system-packages codespell==v2.4.3
     - run: codespell

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.x, oldstable, stable]
-        platform: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-15, macos-26]
+        platform: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, windows-2022, windows-2025, macos-15, macos-26]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 10 # guardrails timeout for the whole job
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,3 +102,18 @@ jobs:
         persist-credentials: false
     - run: pip install --break-system-packages codespell==v2.4.3
     - run: codespell
+
+  zizmor:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10 # guardrails timeout for the whole job
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+      with:
+        # Report findings as workflow annotations rather than uploading
+        # them to the repository's security tab (which needs additional
+        # permissions and GitHub Advanced Security to be enabled).
+        advanced-security: false
+        annotations: true


### PR DESCRIPTION
Rebased on top of #250.

**Bumps:**
 - `actions/checkout`: v6.0.2 → v7.0.1
 - `actions/setup-go`: v6.3.0 → v7.0.0
 - `codecov/codecov-action`: v5.5.3 → v7.0.0
 - `codespell`: 2.3.0 → 2.4.3

All three action bumps are major releases, but the only user-visible change is the move to node24 (and ESM); all runners in our matrix support it.

**Dependabot:** adds `.github/dependabot.yml` for the `github-actions` ecosystem so the pinned digests (and their version comments) stop going stale. Updates are grouped into a single weekly PR with a 7-day cooldown. Go modules are deliberately left out — those are maintained by hand.

**Hardening:** sets `persist-credentials: false` on both `actions/checkout` steps; nothing in this workflow pushes back to the repo.

**zizmor:** adds a job running [zizmor](https://docs.zizmor.sh/), a static analyzer for GitHub Actions workflows, so this kind of thing gets caught automatically from now on. Findings are reported as workflow annotations rather than uploaded to the security tab, so it needs no extra permissions.

**actionlint:** adds a separate workflow running [actionlint](https://github.com/rhysd/actionlint), which validates the workflow syntax, expressions and runner labels, and runs shellcheck over the `run:` scripts.

**ubuntu-26.04:** added to the test matrix. Those runners are still in public preview; all jobs pass on them. actionlint does not know the label yet, so `.github/actionlint.yaml` declares it — to be dropped once an actionlint release includes it.