### PR TITLE
enable all gocritic options

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
         - rangeValCopy
         - sloppyReassign
         - unnamedResult
-        - unnecessaryDefer
         - whyNoLint
       enable-all: true
     staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
         - builtinShadow
         - deferInLoop
         - hugeParam
-        - ifElseChain
         - importShadow
         - paramTypeCombine
         - rangeValCopy

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
         - assignOp
         - builtinShadow
         - deferInLoop
-        - emptyStringTest
         - hugeParam
         - ifElseChain
         - importShadow

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     gocritic:
       disabled-checks:
         - appendAssign
-        - assignOp
         - builtinShadow
         - deferInLoop
         - hugeParam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,17 +13,6 @@ linters:
       - std-error-handling
   settings:
     gocritic:
-      disabled-checks:
-        - appendAssign
-        - builtinShadow
-        - deferInLoop
-        - hugeParam
-        - importShadow
-        - paramTypeCombine
-        - rangeValCopy
-        - sloppyReassign
-        - unnamedResult
-        - whyNoLint
       enable-all: true
     staticcheck:
       # Enable all options, with some exceptions.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ version: "2"
 linters:
   enable:
     - errorlint
+    - gocritic
     - unconvert
     - unparam
   exclusions:
@@ -11,6 +12,23 @@ linters:
       - comments
       - std-error-handling
   settings:
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - assignOp
+        - builtinShadow
+        - deferInLoop
+        - emptyStringTest
+        - hugeParam
+        - ifElseChain
+        - importShadow
+        - paramTypeCombine
+        - rangeValCopy
+        - sloppyReassign
+        - unnamedResult
+        - unnecessaryDefer
+        - whyNoLint
+      enable-all: true
     staticcheck:
       # Enable all options, with some exceptions.
       # For defaults, see https://golangci-lint.run/usage/linters/#staticcheck

--- a/capability/capability_linux.go
+++ b/capability/capability_linux.go
@@ -77,11 +77,12 @@ func mkString(c Capabilities, max CapType) (ret string) {
 	ret = "{"
 	for i := CapType(1); i <= max; i <<= 1 {
 		ret += " " + i.String() + "=\""
-		if c.Empty(i) {
+		switch {
+		case c.Empty(i):
 			ret += "empty"
-		} else if c.Full(i) {
+		case c.Full(i):
 			ret += "full"
-		} else {
+		default:
 			ret += c.StringCap(i)
 		}
 		ret += "\""

--- a/capability/capability_test.go
+++ b/capability/capability_test.go
@@ -133,7 +133,7 @@ func TestNewPid2Load(t *testing.T) {
 	// Assuming that at least bounding set is not empty.
 	bset := c.StringCap(BOUNDING)
 	t.Logf("Bounding set: %s", bset)
-	if len(bset) == 0 {
+	if bset == "" {
 		t.Fatal("loaded bounding set: want non-empty, got empty")
 	}
 }

--- a/mount/flags_unix.go
+++ b/mount/flags_unix.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-var flags = map[string]struct {
+var knownFlags = map[string]struct {
 	clear bool
 	flag  int
 }{
@@ -85,7 +85,7 @@ func MergeTmpfsOptions(options []string) ([]string, error) {
 		if option == "defaults" {
 			continue
 		}
-		if f, ok := flags[option]; ok && f.flag != 0 {
+		if f, ok := knownFlags[option]; ok && f.flag != 0 {
 			// There is only one propagation mode
 			key := f.flag
 			if propagationFlags[option] {
@@ -115,25 +115,25 @@ func MergeTmpfsOptions(options []string) ([]string, error) {
 
 // Parse fstab type mount options into mount() flags
 // and device specific data
-func parseOptions(options string) (int, string) {
+func parseOptions(options string) (flags int, data string) {
 	var (
-		flag int
-		data []string
+		flag     int
+		flagData []string
 	)
 
 	for _, o := range strings.Split(options, ",") {
-		// If the option does not exist in the flags table or the flag
+		// If the option does not exist in the knownFlags table or the flag
 		// is not supported on the platform,
 		// then it is a data value for a specific fs type
-		if f, exists := flags[o]; exists && f.flag != 0 {
+		if f, exists := knownFlags[o]; exists && f.flag != 0 {
 			if f.clear {
 				flag &= ^f.flag
 			} else {
 				flag |= f.flag
 			}
 		} else {
-			data = append(data, o)
+			flagData = append(flagData, o)
 		}
 	}
-	return flag, strings.Join(data, ",")
+	return flag, strings.Join(flagData, ",")
 }

--- a/mount/mounter_linux.go
+++ b/mount/mounter_linux.go
@@ -8,14 +8,14 @@ const (
 	// ptypes is the set propagation types.
 	ptypes = unix.MS_SHARED | unix.MS_PRIVATE | unix.MS_SLAVE | unix.MS_UNBINDABLE
 
-	// pflags is the full set valid flags for a change propagation call.
+	// pflags is the full set valid knownFlags for a change propagation call.
 	pflags = ptypes | unix.MS_REC | unix.MS_SILENT
 
 	// broflags is the combination of bind and read only
 	broflags = unix.MS_BIND | unix.MS_RDONLY
 )
 
-// isremount returns true if either device name or flags identify a remount request, false otherwise.
+// isremount returns true if either device name or knownFlags identify a remount request, false otherwise.
 func isremount(device string, flags uintptr) bool {
 	switch {
 	// We treat device "" and "none" as a remount request to provide compatibility with

--- a/mount/sharedsubtree_linux_test.go
+++ b/mount/sharedsubtree_linux_test.go
@@ -313,9 +313,7 @@ func TestSubtreeUnbindable(t *testing.T) {
 	} else if err == nil {
 		t.Fatalf("%q should not have been bindable", sourceDir)
 	}
-	defer func() {
-		if err := Unmount(targetDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	if err := Unmount(targetDir); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/mountinfo/mountinfo_bsd.go
+++ b/mountinfo/mountinfo_bsd.go
@@ -18,9 +18,9 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 	}
 
 	var out []*Info
-	for _, entry := range entries {
+	for i := range entries {
 		var skip, stop bool
-		mountinfo := getMountinfo(&entry)
+		mountinfo := getMountinfo(&entries[i])
 
 		if filter != nil {
 			// filter out entries we're not interested in

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -41,11 +41,11 @@ func ParseSignal(rawSignal string) (syscall.Signal, error) {
 		}
 		return syscall.Signal(s), nil
 	}
-	signal, ok := SignalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
+	sig, ok := SignalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
 	if !ok {
 		return -1, fmt.Errorf("invalid signal: %s", rawSignal)
 	}
-	return signal, nil
+	return sig, nil
 }
 
 // ValidSignalForPlatform returns true if a signal is valid on the platform

--- a/user/idtools.go
+++ b/user/idtools.go
@@ -49,12 +49,12 @@ func MkdirAndChown(path string, mode os.FileMode, uid, gid int, opts ...MkdirOpt
 
 // getRootUIDGID retrieves the remapped root uid/gid pair from the set of maps.
 // If the maps are empty, then the root uid/gid will default to "real" 0/0
-func getRootUIDGID(uidMap, gidMap []IDMap) (int, int, error) {
+func getRootUIDGID(uidMap, gidMap []IDMap) (uid, gid int, _ error) {
 	uid, err := toHost(0, uidMap)
 	if err != nil {
 		return -1, -1, err
 	}
-	gid, err := toHost(0, gidMap)
+	gid, err = toHost(0, gidMap)
 	if err != nil {
 		return -1, -1, err
 	}
@@ -103,14 +103,14 @@ type IdentityMapping struct {
 // RootPair returns a uid and gid pair for the root user. The error is ignored
 // because a root user always exists, and the defaults are correct when the uid
 // and gid maps are empty.
-func (i IdentityMapping) RootPair() (int, int) {
-	uid, gid, _ := getRootUIDGID(i.UIDMaps, i.GIDMaps)
+func (i IdentityMapping) RootPair() (uid, gid int) {
+	uid, gid, _ = getRootUIDGID(i.UIDMaps, i.GIDMaps)
 	return uid, gid
 }
 
 // ToHost returns the host UID and GID for the container uid, gid.
 // Remapping is only performed if the ids aren't already the remapped root ids
-func (i IdentityMapping) ToHost(uid, gid int) (int, int, error) {
+func (i IdentityMapping) ToHost(uid, gid int) (hostUID, hostGID int, _ error) {
 	var err error
 	ruid, rgid := i.RootPair()
 
@@ -128,7 +128,7 @@ func (i IdentityMapping) ToHost(uid, gid int) (int, int, error) {
 }
 
 // ToContainer returns the container UID and GID for the host uid and gid
-func (i IdentityMapping) ToContainer(uid, gid int) (int, int, error) {
+func (i IdentityMapping) ToContainer(uid, gid int) (ctrUID, ctrGID int, _ error) {
 	ruid, err := toContainer(uid, i.UIDMaps)
 	if err != nil {
 		return -1, -1, err

--- a/user/idtools_unix.go
+++ b/user/idtools_unix.go
@@ -142,7 +142,7 @@ func lookupSubRangesFile(path string, usr User) ([]IDMap, error) {
 			ParentID: idrange.SubID,
 			Count:    idrange.Count,
 		})
-		containerID = containerID + idrange.Count
+		containerID += idrange.Count
 	}
 	return idMap, nil
 }

--- a/user/idtools_unix.go
+++ b/user/idtools_unix.go
@@ -21,8 +21,7 @@ func mkdirAs(path string, mode os.FileMode, uid, gid int, mkAll bool, opts ...Mk
 		return err
 	}
 
-	stat, err := os.Stat(path)
-	if err == nil {
+	if stat, err := os.Stat(path); err == nil {
 		if !stat.IsDir() {
 			return &os.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
 		}
@@ -52,20 +51,20 @@ func mkdirAs(path string, mode os.FileMode, uid, gid int, mkAll bool, opts ...Mk
 			if dirPath == "/" {
 				break
 			}
-			if _, err = os.Stat(dirPath); os.IsNotExist(err) {
+			if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 				paths = append(paths, dirPath)
 			}
 		}
-		if err = os.MkdirAll(path, mode); err != nil {
+		if err := os.MkdirAll(path, mode); err != nil {
 			return err
 		}
-	} else if err = os.Mkdir(path, mode); err != nil {
+	} else if err := os.Mkdir(path, mode); err != nil {
 		return err
 	}
 	// even if it existed, we will chown the requested path + any subpaths that
 	// didn't exist when we called MkdirAll
 	for _, pathComponent := range paths {
-		if err = setPermissions(pathComponent, mode, uid, gid, nil); err != nil {
+		if err := setPermissions(pathComponent, mode, uid, gid, nil); err != nil {
 			return err
 		}
 	}
@@ -106,11 +105,11 @@ func LoadIdentityMapping(name string) (IdentityMapping, error) {
 		return IdentityMapping{}, fmt.Errorf("could not get user for username %s: %w", name, err)
 	}
 
-	subuidRanges, err := lookupSubRangesFile("/etc/subuid", usr)
+	subuidRanges, err := lookupSubRangesFile("/etc/subuid", &usr)
 	if err != nil {
 		return IdentityMapping{}, err
 	}
-	subgidRanges, err := lookupSubRangesFile("/etc/subgid", usr)
+	subgidRanges, err := lookupSubRangesFile("/etc/subgid", &usr)
 	if err != nil {
 		return IdentityMapping{}, err
 	}
@@ -121,7 +120,7 @@ func LoadIdentityMapping(name string) (IdentityMapping, error) {
 	}, nil
 }
 
-func lookupSubRangesFile(path string, usr User) ([]IDMap, error) {
+func lookupSubRangesFile(path string, usr *User) ([]IDMap, error) {
 	uidstr := strconv.Itoa(usr.Uid)
 	rangeList, err := ParseSubIDFileFilter(path, func(sid SubID) bool {
 		return sid.Name == usr.Name || sid.Name == uidstr
@@ -133,7 +132,7 @@ func lookupSubRangesFile(path string, usr User) ([]IDMap, error) {
 		return nil, fmt.Errorf("no subuid ranges found for user %q", usr.Name)
 	}
 
-	idMap := []IDMap{}
+	idMap := make([]IDMap, 0, len(rangeList))
 
 	var containerID int64
 	for _, idrange := range rangeList {

--- a/user/user.go
+++ b/user/user.go
@@ -242,7 +242,7 @@ func GetExecUserPath(userSpec string, defaults *ExecUser, passwdPath, groupPath 
 // the UID to be <= MaxInt32.
 //
 // See https://github.com/containerd/containerd/commit/de1341c201ffb0effebbf51d00376181968c8779
-func parseNumeric(val string) (int, bool, error) {
+func parseNumeric(val string) (id int, ok bool, _ error) {
 	id, err := strconv.Atoi(val)
 	if err != nil {
 		if errors.Is(err, strconv.ErrSyntax) {
@@ -317,7 +317,7 @@ func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (
 			// Default to current state of the user.
 			return u.Uid == user.Uid
 		}
-		return userArg.matches(u)
+		return userArg.matches(&u)
 	})
 
 	// If we can't find the user, we have to bail.

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -139,8 +139,7 @@ func TestParseGroupFileCapsReads(t *testing.T) {
 				pad[len(pad)-1] = '\n'
 			}
 
-			data := append(pad, beyond...)
-			err := os.WriteFile(fileName, data, 0o644)
+			err := os.WriteFile(fileName, append(pad, beyond...), 0o644)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/user/user_utils.go
+++ b/user/user_utils.go
@@ -87,7 +87,7 @@ func parseUserArg(name string) (*userArg, error) {
 
 // matches reports whether user u satisfies the argument. Numeric arguments
 // are matched by UID only, others by name.
-func (ua *userArg) matches(u User) bool {
+func (ua *userArg) matches(u *User) bool {
 	if ua.isNumeric {
 		return u.Uid == ua.uid
 	}


### PR DESCRIPTION
- stacked on https://github.com/moby/sys/pull/253
- stacked on https://github.com/moby/sys/pull/246


These were the failures;


```
mountinfo/mountinfo_bsd.go:21:2: rangeValCopy: each iteration copies 2168 bytes (consider pointers or indexing) (gocritic)
	for _, entry := range entries {
	^
```

```
mount/flags_unix.go:118:1: unnamedResult: consider giving a name to these results (gocritic)
func parseOptions(options string) (int, string) {
^
```


```
signal/signal.go:44:2: importShadow: shadow of imported package 'signal' (gocritic)
	signal, ok := SignalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
	^
```

```
user/idtools.go:52:1: unnamedResult: consider giving a name to these results (gocritic)
func getRootUIDGID(uidMap, gidMap []IDMap) (int, int, error) {
^
user/idtools.go:106:1: unnamedResult: consider giving a name to these results (gocritic)
func (i IdentityMapping) RootPair() (int, int) {
^
user/idtools.go:113:1: unnamedResult: consider giving a name to these results (gocritic)
func (i IdentityMapping) ToHost(uid, gid int) (int, int, error) {
^
user/idtools_unix.go:59:6: sloppyReassign: re-assignment to `err` can be replaced with `err := os.MkdirAll(path, mode)` (gocritic)
		if err = os.MkdirAll(path, mode); err != nil {
		   ^
user/idtools_unix.go:62:12: sloppyReassign: re-assignment to `err` can be replaced with `err := os.Mkdir(path, mode)` (gocritic)
	} else if err = os.Mkdir(path, mode); err != nil {
	          ^
user/idtools_unix.go:68:6: sloppyReassign: re-assignment to `err` can be replaced with `err := setPermissions(pathComponent, mode, uid, gid, nil)` (gocritic)
		if err = setPermissions(pathComponent, mode, uid, gid, nil); err != nil {
		   ^
user/idtools_unix.go:124:39: hugeParam: usr is heavy (96 bytes); consider passing it by pointer (gocritic)
func lookupSubRangesFile(path string, usr User) ([]IDMap, error) {
                                      ^
user/user_test.go:142:12: appendAssign: append result not assigned to the same slice (gocritic)
			data := append(pad, beyond...)
			        ^
user/user_utils.go:90:28: hugeParam: u is heavy (96 bytes); consider passing it by pointer (gocritic)
func (ua *userArg) matches(u User) bool {
                           ^
```