### PR TITLE
mount: fix ensureUnmount gated by build-tag

### DIFF
--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -13,6 +13,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// ensureUnmount umounts mnt checking for errors
+func ensureUnmount(t *testing.T, mnt string) {
+	t.Helper()
+	if err := Unmount(mnt); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestMountOptionsParsing(t *testing.T) {
 	options := "noatime,ro,noexec,size=10k"
 

--- a/mount/mounter_linux_test.go
+++ b/mount/mounter_linux_test.go
@@ -98,13 +98,6 @@ func TestMount(t *testing.T) {
 	}
 }
 
-// ensureUnmount umounts mnt checking for errors
-func ensureUnmount(t *testing.T, mnt string) {
-	if err := Unmount(mnt); err != nil {
-		t.Error(err)
-	}
-}
-
 // validateMount checks that mnt has the given options
 func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 	info, err := mountinfo.GetMounts(nil)


### PR DESCRIPTION
The ensureUnmount utility was defined in a Linux-only file, but referenced from the Unix-tests, which wouldn't compile on non-Linux because of that.

Move it to the Unix test file, and mark it as helper while updating.