### PR TITLE
userns: handle OpenVZ namespace inode virtualization

### DIFF
--- a/userns/userns_linux.go
+++ b/userns/userns_linux.go
@@ -2,6 +2,7 @@ package userns
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -23,7 +24,16 @@ var inUserNS = sync.OnceValue(runningInUserNS)
 func runningInUserNS() bool {
 	var st syscall.Stat_t
 	if err := syscall.Stat("/proc/self/ns/user", &st); err == nil {
-		return st.Ino != procUserInitIno
+		// The kernel's initial user namespace inode is definitive when it
+		// matches. OpenVZ virtualizes namespace inode numbers, so a mismatch
+		// must fall back to uid_map-based detection there.
+		if st.Ino == procUserInitIno {
+			return false
+		}
+		if runningInOpenVZ() {
+			return runningInUserNSFromUIDMap()
+		}
+		return true
 	} else if !os.IsNotExist(err) {
 		// As long as /proc/self/ns/user exists, we are on a modern kernel.
 		// Other errors indicate an unexpected procfs state, where assuming the
@@ -35,6 +45,10 @@ func runningInUserNS() bool {
 	// through procfs at /proc/self/ns/user.
 	// TODO: Remove this fallback once Linux kernels older than 3.8 are no
 	// longer supported.
+	return runningInUserNSFromUIDMap()
+}
+
+func runningInUserNSFromUIDMap() bool {
 	file, err := os.Open("/proc/self/uid_map")
 	if err != nil {
 		// This kernel-provided file only exists if user namespaces are supported.
@@ -68,4 +82,20 @@ func uidMapInUserNS(uidMap string) bool {
 	// the initial user namespace shows 0 0 4294967295.
 	initNS := a == 0 && b == 0 && c == 4294967295
 	return !initNS
+}
+
+// runningInOpenVZ reports whether the process is running inside an OpenVZ
+// container.
+//
+// OpenVZ exposes /proc/vz both on the host and inside containers, while
+// /proc/bc is only exposed on the host. This follows systemd's OpenVZ
+// detection:
+// https://github.com/systemd/systemd/blob/v261.2/src/basic/virt.c#L642-L653
+func runningInOpenVZ() bool {
+	var st syscall.Stat_t
+	if err := syscall.Stat("/proc/vz", &st); err != nil {
+		return false
+	}
+	err := syscall.Stat("/proc/bc", &st)
+	return errors.Is(err, syscall.ENOENT)
 }


### PR DESCRIPTION
relates to:

- https://github.com/moby/sys/pull/240
- https://github.com/containers/crun/issues/2150
- https://github.com/containers/crun/issues/2150
- addresses https://github.com/moby/moby/issues/53592



Commit 023b764009a2 ("userns: detect initial namespace by inode") changed user-namespace detection to compare the inode of /proc/self/ns/user against the kernel's PROC_USER_INIT_INO value. This avoids misidentifying full-range user namespaces, such as those created by systemd's PrivateUsers=full, as the initial namespace.

OpenVZ, however, virtualizes the namespace inode numbers exposed through procfs, so PROC_USER_INIT_INO cannot reliably identify the initial user namespace there.

Detect when running inside an OpenVZ container using the same procfs checks as systemd, and fall back to the uid_map-based detection in that case.

Keep the namespace-inode check as the preferred path elsewhere, while preserving the existing uid_map fallback for older kernels.

updates: 023b764009a2ac590dbe08382d2250b7b06ed68b



```markdown release-note
userns: fix user-namespace detection on OpenVZ, where namespace inode numbers are virtualized.
```
