### PR TITLE
CI: switch to kjanat/actionlint v1.16.0

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,0 @@
-# ubuntu-26.04 is still in public preview, and actionlint does not know
-# about it yet; remove this once it does.
-self-hosted-runner:
-  labels:
-    - ubuntu-26.04

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,4 +23,4 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: devops-actions/actionlint@ec02b36684b2f574f1d219ad0a43b082e46bf3e4 # v0.1.13
+    - uses: kjanat/actionlint@733ac2f73f6d80c269aa7a02d1ee83673fa5ab33 # v1.16


### PR DESCRIPTION
The `devops-actions/actionlint` wrapper runs an old `rhysd/actionlint`
release. Use the maintained `kjanat/actionlint` fork's own action instead,
pinned to the commit that pins its container image by digest (as
recommended by its README; the release tag itself references the image
by a floating tag).

Since v1.16.0 knows about the `ubuntu-26.04` runner label, the
`self-hosted-runner` escape hatch in `.github/actionlint.yaml` is no
longer needed, so drop it.

Checked locally with the v1.16.0 binary (the same one the action's
container runs), without `.github/actionlint.yaml`: no findings.